### PR TITLE
Expose docker control port and socket

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -4,8 +4,10 @@
 
 start(){
     # TODO move this logfile out of /var/lib/docker
+    # Capture docker0 IP address, in the extremely unlikely event it ever changes
+    DOCKER_ADDR = `/sbin/ifconfig docker0 | grep 'inet addr:' | cut -d: -f2| cut -d' ' -f1`
     # Allow dockerd access from the container network (so that we can use shipyard, etc.)
-    /usr/local/bin/docker -d -H tcp://172.17.42.1:4243 -H unix:///var/run/docker.sock > /var/lib/docker/docker.log 2>&1 &
+    /usr/local/bin/docker -d -H tcp://$DOCKER_ADDR:4243 -H unix:///var/run/docker.sock > /var/lib/docker/docker.log 2>&1 &
 }
 
 stop(){


### PR DESCRIPTION
So that we can use shipyard inside boot2docker
