### PR TITLE
explain why not CoreOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ FAQ
 
 **Why not CoreOS?**
 
-I got asked that question a lot, so I thought I should put it here once and for all. I liked the original idea of CoreOS: the smallest possible way to boot to docker. Unfortunately CoreOS has been growing larger and just did too many things for me. I just wanted the fastest way to boot to Docker.
+I got asked that question a lot, so I thought I should put it here once and for all. CoreOS is targeted at building infrastructure and distributed systems. I just wanted the fastest way to boot to Docker.


### PR DESCRIPTION
This PR changes the README to explain why CoreOS wasn't the Linux distribution @steeve wanted and that he just wanted something as small as possible.

CoreOS will always be a bit bigger than the most minimal Linux distro because it's targeted at building complex infrastructure. This should be clear to everyone so they can try out CoreOS and boot2docker, maybe even end up using both for different purposes ;).

Thank you, @steeve !
