### PR TITLE
Modify source of 2nd stage build in rootfs/Dockerfile

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM steeve/boot2docker-base
+FROM boot2docker-base
 MAINTAINER Steeve Morin "steeve.morin@gmail.com"
 
 ENV ROOTFS          /rootfs


### PR DESCRIPTION
The original line didn't work for me in trying to rebuild boot2docker. I believe this is because the image generated in the 1st step of the build process doesn't get used without this modification. This seems to build correctly after making this modification. 
