### PR TITLE
Update README to mention Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ boot2docker auto logs in, but if you want to SSH into the machine, the credentia
 ```
 Make sure to setup a port forward from host to guest port 22. Avoid bridged networking due to the static login and password.
 
+boot2docker is also available as a [Vagrant](http://www.vagrantup.com) box: https://github.com/mitchellh/boot2docker-vagrant-box
+
 Demo
 ----
 http://www.youtube.com/watch?v=QzfddDvNVv0


### PR DESCRIPTION
This adds a link to the boot2docker Vagrant box repo. Alternatively, it'd be cool if you wanted to just take that repo and put it into the boot2docker repo to make it easier to discover. It barely modifies boot2docker, just adding the Vagrant SSH key to it. 

In the next version of Vagrant, this won't even be necessary since Vagrant will be able to auth with SSH passwords. 

Related to #29 
