### PR TITLE
Execute createvm command instead of logging it

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -30,7 +30,7 @@ init() {
     BOOT2DOCKER_ISO=./boot2docker.iso
 
     log "Creating VM $VM_NAME"
-    log $VBM createvm --name $VM_NAME --register
+    $VBM createvm --name $VM_NAME --register
 
     log "Setting VM settings"
     $VBM modifyvm $VM_NAME \


### PR DESCRIPTION
When running `./boot2docker init` I was getting lots of errors like the following:

```
VBoxManage: error: Could not find a registered machine named 'boot2docker-vm'
```

This patch fixes that error.
