### PR TITLE
Fix automount issue #26 (attached disk image is not automounted)

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -3,5 +3,6 @@
 
 FIRST_HD=`autoscan-devices | cut -d' ' -f1`
 if [ -n "$FIRST_HD" ]; then
+    mkdir -p /var/lib/docker
     mount /dev/$FIRST_HD /var/lib/docker
 fi


### PR DESCRIPTION
The problem with automounts not working for attached disk images is due to the mountpoint not being available when the mount command runs and thus the mount fails.

This simply does a `mkdir -p` prior to the mount which then makes sure that the mount works correctly.

This PR fixes issue https://github.com/steeve/boot2docker/issues/26
