### PR TITLE
Expose docker on port 4243 so you can control it from os x docker client

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -4,7 +4,8 @@
 
 start(){
     # TODO move this logfile out of /var/lib/docker
-    /usr/local/bin/docker -d -H unix:///var/run/docker.sock -H tcp://0.0.0.0:4243 > /var/lib/docker/docker.log 2>&1 &
+    /bin/dmesg | /bin/grep VirtualBox > /dev/null && EXPOSE_ALL="-H tcp://0.0.0.0:4243"
+    /usr/local/bin/docker -d -H unix:///var/run/docker.sock $EXPOSE_ALL > /var/lib/docker/docker.log 2>&1 &
 }
 
 stop(){


### PR DESCRIPTION
The `boot2docker` command line use NAT to port `4243` but the docker daemon that runs in the image doesn't expose itself on 4243.

This PR exposes port 4243 for docker command such as from the new `0.7.3` docker client for Mac.

FWIW this is also what `docker-osx` does as well, but `boot2docker` is way more awesome in it's speed and minimalism! :-)
