### PR TITLE
Expose port 4243 for VMWare Fusion and QEMU

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -4,7 +4,7 @@
 
 start(){
     # TODO move this logfile out of /var/lib/docker
-    /bin/dmesg | /bin/grep VirtualBox > /dev/null && EXPOSE_ALL="-H tcp://0.0.0.0:4243"
+    /bin/dmesg | /bin/egrep '(VirtualBox|VMware|QEMU)' > /dev/null && EXPOSE_ALL="-H tcp://0.0.0.0:4243"
     /usr/local/bin/docker -d -H unix:///var/run/docker.sock $EXPOSE_ALL > /var/lib/docker/docker.log 2>&1 &
 }
 


### PR DESCRIPTION
Currently getting docker to expose itself on `0.0.0.0:4243` for the Mac OS X command line client is limited to VirtualBox detection (see https://github.com/steeve/boot2docker/pull/60). 

This PR adds support for both QEMU and VMWare Fusion. I've tested this in both the latest QEMU in brew and also VMWare Fusion 5 and VirtualBox 4.3.6.
