### PR TITLE
Disable frame buffer graphics mode on boot

### DIFF
--- a/rootfs/isolinux/isolinux.cfg
+++ b/rootfs/isolinux/isolinux.cfg
@@ -3,7 +3,7 @@ default boot2docker
 label boot2docker
 	kernel /boot/vmlinuz64
 	initrd /boot/initrd.img
-	append loglevel=3 user=docker console=ttyS0 console=tty0
+	append loglevel=3 user=docker console=ttyS0 console=tty0 nomodeset
 
 implicit 0
 prompt 1


### PR DESCRIPTION
Currently boot2docker changes from text mode to graphics mode during boot up with 3 consequences:
1. Going to graphics mode seems to be disabling logging when attempting to run boot2docker 100% headless without a monitor (such as with qemu with the -nographic option), which causes this issue https://github.com/steeve/boot2docker/issues/15
2. When running boot2docker in a virtual machine such as VMWare of QEMU, the terminal window resizes to 1280x1024 and on many monitors or laptops this means that the bottom part of the terminal scrolls off the screen making for poor usability.
3. Running boot2docker on bare metal without a monitor may cause issues as it tries to change to a graphic mode, or with certain graphics cards may have issues (from my googling, disabling graphics on bootup can solve some graphic card issues like hanging).
