### PR TITLE
virtual box / set hwclock in VM to not beeing UTC

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -48,6 +48,7 @@ init() {
         --ostype $VM_OSTYPE \
         --cpus $VM_CPUS \
         --memory $VM_MEM \
+        --rtcuseutc on \
         --acpi on \
         --hpet on \
         --hwvirtex on \


### PR DESCRIPTION
as most VMs run on systems with hwclock is not set to UTC this should be the default setting
