### PR TITLE
Virtual box / better performance networkadapter VIRTIO

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -29,7 +29,7 @@ init() {
 
     VM_MEM=1024
     VM_OSTYPE=Linux26_64
-    VM_NIC=82540EM
+    VM_NIC=virtio
     VM_DISK=./boot2docker.vmdk
     VM_DISK_SIZE=40000
     unamestr=`uname`


### PR DESCRIPTION
The "Paravirtualized network adapter (virtio-net)" is special. If you select this, then VirtualBox does not virtualize common networking hardware (that is supported by common guest operating systems out of the box). Instead, VirtualBox then expects a special software interface for virtualized environments to be provided by the guest, thus avoiding the complexity of emulating networking hardware and improving network performance.

https://www.virtualbox.org/manual/ch06.html#nichardware

the driver exists in tiny core linux
