### PR TITLE
add missing ioapic

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -49,6 +49,7 @@ init() {
         --cpus $VM_CPUS \
         --memory $VM_MEM \
         --acpi on \
+        --ioapic on \
         --hpet on \
         --hwvirtex on \
         --firmware bios \


### PR DESCRIPTION
http://www.virtualbox.org/manual/ch03.html#intro-64bitguests

Warning
On any host, you should enable the I/O APIC for virtual machines that you intend to use in 64-bit mode.
