### PR TITLE
OSX / build process for ISO fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ So the build process goes like this:
 Once that's done, to build a custom `boot2docker.iso`, just run the built rootfs image:
 ```
     $ sudo docker rm build-boot2docker
-    $ sudo docker run --privileged -name build-boot2docker boot2docker
+    $ sudo docker run -i -privileged -name build-boot2docker boot2docker
     $ sudo docker cp build-boot2docker:/boot2docker.iso .
 ```
 


### PR DESCRIPTION
Setup:
- OSX native docker client - connects thru TCIP
- virtualbox with boot2docker

OSX:$ docker run --privileged -name build-boot2docker boot2docker
9937 blocks

Output stops no ISO created

doing the same inside the virtual box - there is no problem to create th ISO image
