### PR TITLE
Checking return of VBoxManage modifyvm

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -44,7 +44,7 @@ init() {
     $VBM createvm --name $VM_NAME --register
 
     log "Setting VM settings"
-    $VBM modifyvm $VM_NAME \
+    if ! $VBM modifyvm $VM_NAME \
         --ostype $VM_OSTYPE \
         --cpus $VM_CPUS \
         --memory $VM_MEM \
@@ -59,7 +59,11 @@ init() {
         --nestedpaging on \
         --firmware bios \
         --bioslogofadein off --bioslogofadeout off --bioslogodisplaytime 0 --biosbootmenu disabled \
-        --boot1 dvd
+        --boot1 dvd; then
+      echo "An error occured, upgrade VirtualBox or try to disable some options"
+      delete
+      exit 1
+    fi
 
     log "Setting VM networking"
     $VBM modifyvm $VM_NAME \


### PR DESCRIPTION
Checking return of `VBoxManage modifyvm`

Some options may be unavailable in prior version of `VirtualBox` causing `modifyvm` to fail

Without this patch, the script continue with an unconfigured virtual machine without enough ram to boot the kernel
