### PR TITLE
Added an hostonly interface with fixed ip address for guest and host

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -138,8 +138,34 @@ init() {
     $VBM storageattach $VM_NAME --storagectl "SATA" --port 0 --device 0 --type dvddrive --medium $BOOT2DOCKER_ISO
     $VBM storageattach $VM_NAME --storagectl "SATA" --port 1 --device 0 --type hdd --medium $VM_DISK
 
+    setup_etc_hosts
+
     log "Done."
     log "You can now type boot2docker up and wait for the VM to start."
+}
+
+setup_etc_hosts() {
+    if grep -q localdocker /etc/hosts; then
+        return
+    fi
+
+    line="$DOCKER_IP localdocker"
+
+    echo
+    echo "Adding localdocker alias to /etc/hosts (may need your password for sudo)."
+    echo "To perform this step manually, add this line to /etc/hosts:"
+    echo
+    echo "    $line"
+    echo
+    echo "Or skip it and just use the IP directly."
+    echo
+
+    read -p "Add localdocker alias to /etc/hosts? [yN] " -n 1 -r
+    echo
+
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        sudo sh -c "echo '$line' >> /etc/hosts"
+    fi
 }
 
 do_ssh() {


### PR DESCRIPTION
With this secondary interface we can now publish ports (`docker run ... -p 8000:80` for instance) without needs to configure new nat rules

The `docker` ip is `172.18.42.1`, the `host` ip is `172.18.42.254`

Since it's a secondary interface, it don't brake anything, you can still use `127.0.0.1:2022` and `127.0.0.1:4243`

TODO:
- [x] Add secondary interface
- [x] Create an auto-setup for /etc/hosts (like https://github.com/noplay/docker-osx/blob/master/docker-osx#L37-L61)
- [ ] Update the `DOCKER_HOST` in .bashrc ?
- [ ] Documentation

cc #85 (Give the VM a hostname in the init script)
cc https://github.com/steeve/boot2docker/pull/87 (NFS Client & Server, create a second host only network interface)
cc #84 (Automatically mount home directory in init script)
cc https://github.com/steeve/boot2docker/pull/73 (boot2docker / Forward all dynamic assigned ports)
cc #64 (nfs share / guest to host)
cc #104 (boot2docker / docker auto mapping port forwarding)
cc #62 (nfs volume)
