### PR TITLE
boot2docker / docker auto mapping port forwarding

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -226,6 +226,81 @@ delete() {
     $VBM unregistervm --delete $VM_NAME
 }
 
+docker_cmd() {
+    echo "CMD: $@"
+    DCMD=$@
+    if [[ $DCMD =~ [-]name[[:space:]]([a-zA-Z0-9_-]+) ]]; then
+        CNAME=${BASH_REMATCH[1]}
+        # echo "name: $CNAME"
+    fi
+    if [[ -n "$CNAME" ]] && [[ $DCMD =~ -p[[:space:]]([a-zA-Z0-9_\\-\\.]*):*([0-9]*):*([0-9]*)(/udp){0,1} ]]; then
+        # echo $BASH_REMATCH      
+        # echo ${BASH_REMATCH[1]} 
+        # echo ${BASH_REMATCH[2]} 
+        # echo ${BASH_REMATCH[3]} 
+        # echo ${BASH_REMATCH[4]}
+        PP0=$BASH_REMATCH
+        PP1=${BASH_REMATCH[1]}
+        PP2=${BASH_REMATCH[2]}
+        PP3=${BASH_REMATCH[3]}
+        PP4=${BASH_REMATCH[4]}
+        if [[ $PP1 =~ [a-zA-Z0-9](-*[a-zA-Z0-9]+)*(\.[a-zA-Z0-9](-*[a-zA-Z0-9]+)*)+ ]]; then
+            PB_HOST_IF=$PP1
+            if [ "" == "$PP3" ]; then
+                PB_CPORT=$PP2
+            else
+                PB_CPORT=$PP3
+                PB_HPORT=$PP2
+            fi
+        else
+            # echo "no IP"
+            if [ "" == "$PP2" ]; then
+                PB_CPORT=$PP1
+            else
+                PB_CPORT=$PP2
+                PB_HPORT=$PP1
+            fi
+        fi
+        PB_OPTION="-p 0.0.0.0::$PB_CPORT"
+        if [ "" == "$PP4" ]; then
+            PB_TYP=tcp
+        else
+            PB_TYP=udp
+        fi
+        # echo "$PB_HOST_IF:$PB_HPORT:$PB_CPORT"
+        # echo "$PB_OPTION"
+        DCMD="${DCMD/$PP0/$PB_OPTION}"
+        echo "docker $DCMD"
+
+        docker $DCMD
+        # echo "docker port $CNAME $PB_CPORT"
+        PBDYN=$(docker port $CNAME $PB_CPORT)
+        # echo $PBDYN
+        if [[ $PBDYN =~ ([a-zA-Z0-9_\\-\\.]*):*([0-9]*) ]]; then
+            PB_VM_IF=${BASH_REMATCH[1]}
+            # PB_VM_IF=""
+            PB_DPORT=${BASH_REMATCH[2]}
+            if [ "" == "$PB_HOST_IF" ]; then
+                PB_HOST_IF="127.0.0.1"
+            fi
+            if [ "" == "$PB_HPORT" ]; then
+                PB_HPORT=$PB_DPORT
+            fi
+            CFWPORTS=""
+            CFWPORTS="$CFWPORTS natpf1 zfp$PB_HPORT,$PB_TYP,$PB_HOST_IF,$PB_HPORT,$PB_VM_IF,$PB_DPORT"
+            #echo $CFWPORTS
+            echo "$VBM controlvm $VM_NAME natpf1 delete zfp$PB_HPORT"
+            echo "$VBM controlvm $VM_NAME $CFWPORTS"
+            $VBM controlvm $VM_NAME setlinkstate1 off
+            $VBM controlvm $VM_NAME natpf1 delete zfp$PB_HPORT  > /dev/null 2>&1
+            $VBM controlvm $VM_NAME $CFWPORTS
+            $VBM controlvm $VM_NAME setlinkstate1 on
+        fi
+    else
+        docker $1
+    fi
+}
+
 case $1 in
     init | setup) init;;
     start | up) start;;
@@ -237,5 +312,6 @@ case $1 in
     delete) delete;;
     ssh) shift; do_ssh "$@";;
     download) download_latest;;
-    *) echo "Usage $0 {init|start|up|pause|stop|restart|status|info|delete|ssh|download}"; exit 1
+    cmd) shift; docker_cmd "$@";;
+    *) echo "Usage $0 {init|start|up|pause|stop|restart|status|info|delete|ssh|download|cmd}"; exit 1
 esac


### PR DESCRIPTION
Hi

this is my first version - not ready for production!!!
- Implements a wrapper for `docker`
- parses the docker parameter `-p` and `-name`
- will modify port redirection to suport virtual environments 
- automatical create dynamical the needed port forwarding rules for virtual box

**Examples:**

```
# setup test
docker pull  tutum/apache-php

# Bind TCP port 80 of the container to TCP port 8080 on 127.0.0.1 of the host machine.
./boot2docker cmd docker run -p 127.0.0.1:8080:80 -name webserver tutum/apache-php /run.sh

# Bind TCP port 80 of the container to a dynamically allocated TCP port on 127.0.0.1 of the host machine.
./boot2docker cmd docker run -p 127.0.0.1::80 -name webserver tutum/apache-php /run.sh

# THIS IS THE PREFERED WAY
# Bind TCP port 80 of the container to TCP port 8080 on all available interfaces of the host machine.
./boot2docker cmd docker run -p 8080:80 -name webserver tutum/apache-php /run.sh

# Bind TCP port 80 of the container to a dynamically allocated TCP port on all available interfaces of the host machine.
./boot2docker cmd docker run -p 80 -name webserver tutum/apache-php /run.sh
```

**Requirements:**
-  the container needs to be named: -name <name>
- docker will always using dynamical ports inside the VM but the virtual box will forward the defined host port to the dynamic port inside the VM. If you do not define a host port the host port is identical to the dynamical assigned port.

At the moment there is no clean up of the created port forwarding rules except if one rule replaces an existing rule.

This should help to avoid to create not needed port forwarding rules #73 and allows very simple fixed port mapping for development needs #85

looking forward for your feedback
