### PR TITLE
boot2docker / fix broken get last release version function if curl UA is set to IE

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -15,14 +15,24 @@ BOOT2DOCKER_ISO=./boot2docker.iso
 test -f $HOME/.boot2docker/profile && . $HOME/.boot2docker/profile
 
 get_latest_release_name() {
-    curl 'https://api.github.com/repos/steeve/boot2docker/releases' 2>/dev/null | grep "tag_name" | awk '{print $2}' | sed 's/[",]*//g' | head -1
+    local LRN=$(curl 'https://api.github.com/repos/steeve/boot2docker/releases' 2>/dev/null | grep -o -m 1 -e "\"tag_name\":[[:space:]]*\"[a-z0-9.]*\"" | head -1)
+    if [[ $LRN =~ \"tag_name\":[[:space:]]*\"(.*)\" ]]; then
+        echo ${BASH_REMATCH[1]}
+    else
+        echo "ERROR"
+    fi
 }
 
 download_latest() {
     LATEST_RELEASE=`get_latest_release_name`
-    log "Latest version is $LATEST_RELEASE, downloading..."
-    curl -L -o boot2docker.iso "https://github.com/steeve/boot2docker/releases/download/$LATEST_RELEASE/boot2docker.iso"
-    log "Done"
+    if [ ! "$LATEST_RELEASE" == "ERROR" ]; then
+        log "Latest version is $LATEST_RELEASE, downloading..."
+        mkdir -p "${BOOT2DOCKER_ISO%/*}"
+        curl -L -o "$BOOT2DOCKER_ISO" "https://github.com/steeve/boot2docker/releases/download/$LATEST_RELEASE/boot2docker.iso"
+        log "Done"
+    else 
+        log "Could not get lastest release name! Cannot download boot2docker.iso."
+    fi
 }
 
 log() {


### PR DESCRIPTION
a `curl -A "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)" 'https://api.github.com/repos/steeve/boot2docker/releases'`
this will return a JSON with windows line feeds which did not get correctly parsed

add more error handling

fixes this #106
