### PR TITLE
Minor fix: Some hardware architecture don't support the --vtxux for VBoxManage modifyvm

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -59,6 +59,11 @@ init() {
     $VBM createvm --name $VM_NAME --register
 
     log "Setting VM settings"
+    TXUX_SUPPORT=""
+    if $($VBM modifyvm|grep -q "\-\-vtxux"); then
+        TXUX_SUPPORT="--vtxux on"
+    fi
+
     if ! $VBM modifyvm $VM_NAME \
         --ostype $VM_OSTYPE \
         --cpus $VM_CPUS \
@@ -69,7 +74,7 @@ init() {
         --hpet on \
         --hwvirtex on \
         --vtxvpid on \
-        --vtxux on \
+        $TXUX_SUPPORT \
         --largepages on \
         --nestedpaging on \
         --firmware bios \


### PR DESCRIPTION
My current hardware architecture has no support for [Intel VT-x](http://www.virtualbox.org/manual/ch08.html).

> --vtxux on|off: If hardware virtualization is enabled, for Intel VT-x only, this setting enables or disables the use of the unrestricted guest mode feature for executing your guest.

This hotfix makes the usage of `--vtxux` optional.
