### PR TITLE
Add "set -e" to make_iso.sh

### DIFF
--- a/rootfs/make_iso.sh
+++ b/rootfs/make_iso.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Download Tiny Core Linux rootfs
 cd $ROOTFS


### PR DESCRIPTION
This way, if a command fails, the script stops instead of barrelling onwards.

Fixes #116
