### PR TITLE
Helpful tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ chmod +x boot2docker
 $ ./boot2docker init
 $ ./boot2docker up
 $ ./boot2docker ssh
+docker@localhost's password: tcuser
 ```
 
 If `ssh` complains about the keys:
@@ -67,7 +68,7 @@ If you want to use the brand new Docker OSX client, just tell it to connect to `
 
 ```
 $ ./boot2docker up
-$ export DOCKER_HOST=localhost
+$ export DOCKER_HOST="tcp://localhost:4243"
 $ ./docker version
 
 ```


### PR DESCRIPTION
I added the ssh password where it is needed in the instructions, since it had me stumped for a moment.

Secondly, I needed to set `DOCKER_HOST` to `tcp://localhost:4243` rather than just `localhost` for it to work with [Fig](https://github.com/orchardup/fig) (and presumably other tools which rely on this environment variable). Until I specified the full URL, I was simply seeing an obscure python error.
