### PR TITLE
unix golf: replace grep-head-cut-tr pipeline w/awk

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -16,7 +16,7 @@ test -f $HOME/.boot2docker/profile && . $HOME/.boot2docker/profile
 
 get_latest_release_name() {
     local LRN
-    LRN=$(curl -s 'https://api.github.com/repos/steeve/boot2docker/releases' | awk -F\" '/tag_name/{print $4;exit}' RS=,)
+    LRN=$(curl -fs 'https://api.github.com/repos/steeve/boot2docker/releases' | awk -F\" '/tag_name/{print $4;exit}' RS=,)
     if [ -z "$LRN" ]; then
         echo "ERROR"
     else


### PR DESCRIPTION
Tested on Darwin 12.5 awk 20070501, mawk 1.3.3, and GNU Awk 3.1.7.
'-s' replaces '2>/dev/null'
