### PR TITLE
Include link to Boxen/Puppet module in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ $ brew tap homebrew/binary
 $ brew install docker
 ```
 
+There's also a [Puppet module](https://github.com/morgante/puppet-docker) available, if you want to install with Boxen.
+
 Features
 --------
 * Kernel 3.12.1 with AUFS


### PR DESCRIPTION
I wrote a simple little Boxen module to make installing this Docker and boot2docker very easy on new OS X machines.
