### PR TITLE
added natpf command for easy NAT port-forwarding settings.

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -149,6 +149,11 @@ do_ssh() {
     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $SSH_HOST_PORT docker@localhost $*
 }
 
+do_natpf() {
+    is_installed || status
+    $VBM controlvm $VM_NAME natpf1 $*
+}
+
 start() {
     is_installed || status
     if ! is_running; then
@@ -268,6 +273,7 @@ case $1 in
     info) info;;
     delete) delete;;
     ssh) shift; do_ssh "$@";;
+    natpf) shift; do_natpf "$@";;
     download) download_latest;;
-    *) echo "Usage $0 {init|start|up|pause|stop|restart|status|info|delete|ssh|download}"; exit 1
+    *) echo "Usage $0 {init|start|up|pause|stop|restart|status|info|delete|ssh|natpf|download}"; exit 1
 esac


### PR DESCRIPTION
There are many times to set NAT port-forwarding settings. 

For example, http://docs.docker.io/en/latest/examples/nodejs_web_app/ 
I'd like to see that application from locale browser.

So, I added VBoxManage's controlvm command's wrapper.

```
$ boot2docker natpf "node,tcp,127.0.0.1,49160,,49160"
$ boot2docker natpf delete node
```
