### PR TITLE
install & run ntpclient to make sure boot2docker's clock is set

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,8 @@ ENV TCZ_DEPS        iptables \
                     bash \
                     ncurses-common ncurses-terminfo ncurses ncurses-utils \
                     xz liblzma \
-                    git expat2 libiconv libidn libgpg-error libgcrypt libssh2 curl
+                    git expat2 libiconv libidn libgpg-error libgcrypt libssh2 \
+                    curl ntpclient
 
 
 RUN apt-get -y install  squashfs-tools \

--- a/rootfs/rootfs/bootsync.sh
+++ b/rootfs/rootfs/bootsync.sh
@@ -11,6 +11,9 @@
 # set the hostname
 /etc/rc.d/hostname
 
+# sync the clock
+/usr/local/bin/ntpclient -s -h pool.ntp.org
+
 # TODO: move this (and the docker user creation&pwd out to its own over-rideable?))
 if grep -q '^docker:' /etc/passwd; then
     # if we have the docker user, let's create the docker group


### PR DESCRIPTION
I couldn't get Chef to run in boot2docker-hosted containers because the clock in the VM was too skewed. Apparently you can sync the VM clock with the host's using VirtualBox guest additions, but I'm assuming those aren't installed in boot2docker.

This installs the ntpclient package in Tiny Core and runs it against pool.ntp.org in bootsync.sh.
