### PR TITLE
Update boot2docker

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -57,12 +57,12 @@ init() {
     esac
 
     if `nc -z -w2 localhost $DOCKER_PORT > /dev/null` ; then
-        log "DOCKER_PORT=$DOCKER_PORT on localhost is used by an other process! Change the port to a free port."
+        log "DOCKER_PORT=$DOCKER_PORT on localhost is used by another process (e.g. CrashPlan)! Change the value of DOCKER_PORT in the boot2docker script to a free port."
         exit 1
     fi
 
     if `nc -z -w2 localhost $SSH_HOST_PORT > /dev/null` ; then
-        log "SSH_HOST_PORT=$SSH_HOST_PORT on localhost is used by an other process! Change the port to a free port."
+        log "SSH_HOST_PORT=$SSH_HOST_PORT on localhost is used by another process! Change the value of SSH_HOST_PORT in the boot2docker script to a free port."
         exit 1
     fi
 


### PR DESCRIPTION
When running boot2docker on my Mac, I ran into this error:

`"DOCKER_PORT=4243 on localhost is used by an other process!"`

Googling for the error message, I came across [this page (in Japanese)](http://www.akiyan.com/blog/archives/2014/02/osx-docker-with-crashplan.html).  But the thing I noticed is the mention of CrashPlan.  I'm also running CrashPlan so it looks like there is a conflict there.

It took me a while to figure out how to deal with this, so I tried to improve the diagnostic message a little bit so other people (after me), could address this a bit more quickly.
