### PR TITLE
run ntpclient by default, let the user to configure it by setting NTP_SERVER, including disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,11 @@ boot2docker will first try to mount a partition labeled ``boot2docker-data``, if
 
 **Local Customisation (with persistent partition)**
 
-If you have a persistence partition, you can make quick customisations that are run at boot time 
+If you have a persistence partition, you can make customisations that are run at the end of the boot initialisation 
 in the ``/var/lib/boot2docker/bootlocal.sh`` file.
+
+You can also set variables that will be used during the boot initialisation (after the automount) by setting them in
+``/var/lib/boot2docker/profile`` - at this point, its only ``NTP_SERVER``.
 
 for example, to download ``pipework``, install its pre-requisites (which you can download using ``tce-load -w package.tcz``), and then start a container:
 

--- a/rootfs/rootfs/bootsync.sh
+++ b/rootfs/rootfs/bootsync.sh
@@ -8,15 +8,15 @@
 
 mkdir -p /var/lib/boot2docker/log
 
-#import settings from profile (NTP_SERVER)
+#import settings from profile (or unset them)
+export NTP_SERVER=pool.ntp.org
 test -f "/var/lib/boot2docker/profile" && . "/var/lib/boot2docker/profile"
-
 
 # set the hostname
 /etc/rc.d/hostname
 
 # sync the clock (in the background, it takes 40s to timeout)
-/etc/rc.d/ntpclient > /var/lib/boot2docker/log/ntpclient.log 2>&1 &
+/etc/rc.d/ntpclient &
 
 # TODO: move this (and the docker user creation&pwd out to its own over-rideable?))
 if grep -q '^docker:' /etc/passwd; then

--- a/rootfs/rootfs/etc/rc.d/ntpclient
+++ b/rootfs/rootfs/etc/rc.d/ntpclient
@@ -1,4 +1,8 @@
 #!/bin/sh
 
-: ${NTP_SERVER:=pool.ntp.org}
-/usr/local/bin/ntpclient -s -h $NTP_SERVER
+if [ -n "$NTP_SERVER" ]; then
+	echo "running ntpclient -s -h $NTP_SERVER in background" > /var/lib/boot2docker/log/ntpclient.log 2>&1 
+	/usr/local/bin/ntpclient -s -h $NTP_SERVER >> /var/lib/boot2docker/log/ntpclient.log 2>&1 
+else
+	echo "Skipping ntpclient" > /var/lib/boot2docker/log/ntpclient.log 2>&1 
+fi


### PR DESCRIPTION
I'm not entirely convinced that we should default to not running ntpclient, but here's a PR so we can discuss it
