### PR TITLE
fix boot2docker.iso not using config variable

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -126,6 +126,7 @@ init() {
     if [ ! -e "$VM_DISK" ]; then
         log "Creating $VM_DISK_SIZE Meg hard drive..."
         # closemedium may complain when not needed
+        mkdir -p "${VM_DISK%/*}"
         $VBM closemedium disk "$VM_DISK" > /dev/null 2>&1
         ## make a simple text file, and use that as the flag to say 'format me'
         $VBM createhd --format VMDK --filename "$VM_DISK" --size $VM_DISK_SIZE


### PR DESCRIPTION
create non existing directory structure for boot2docker.iso and boot2docker.vmdk

rebased @aheissenberger's change, as I held it up for no good reason :/

closes #101
