### PR TITLE
Added a `boot2docker version` command

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+BOOT2DOCKER_VERSION=0.5.5
+
 #Load the user's profile and then default any remaining values
 test -f "$HOME/.boot2docker/profile" && . "$HOME/.boot2docker/profile"
 : ${VM_NAME:=boot2docker-vm}
@@ -272,6 +274,10 @@ delete() {
     $VBM unregistervm --delete $VM_NAME
 }
 
+version() {
+    echo $BOOT2DOCKER_VERSION
+}
+
 case $1 in
     init | setup) init;;
     start | up) start;;
@@ -283,5 +289,6 @@ case $1 in
     delete) delete;;
     ssh) shift; do_ssh "$@";;
     download) download_latest;;
-    *) echo "Usage $0 {init|start|up|save|pause|stop|restart|status|info|delete|ssh|download}"; exit 1
+    version) version;;
+    *) echo "Usage $0 {init|start|up|save|pause|stop|restart|status|info|delete|ssh|download|version}"; exit 1
 esac


### PR DESCRIPTION
So it's easy to see which version of boot2docker I'm using.
