### PR TITLE
Support for more than one running VM, with a different VM_NAME

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -12,7 +12,7 @@ test -f "$HOME/.boot2docker/profile" && . "$HOME/.boot2docker/profile"
 : ${VM_DISK_SIZE:=40000}
 : ${VM_MEM:=1024}
 
-: ${VM_DISK:=${BOOT2DOCKER_CFG_DIR}/boot2docker.vmdk}
+: ${VM_DISK:=${BOOT2DOCKER_CFG_DIR}/${VM_NAME}.vmdk}
 : ${BOOT2DOCKER_ISO:=${BOOT2DOCKER_CFG_DIR}/boot2docker.iso}
 
 mkdir -p "${BOOT2DOCKER_CFG_DIR}"


### PR DESCRIPTION
I have a need to spin up more than one VM to represent different production servers in a local dev environment.

b2d works nearly well enough, except that the virtual disk is shared between two running VMs.  By using VM_NAME as part of VM_DISK, two different VMs don't have to share one vmdk file.

This pull request should allow me to do something like the below and have it "just work"

```
VM_NAME="frontend" DOCKER_PORT=4000 SSH_HOST_PORT=3000 boot2docker init
VM_NAME="backend" DOCKER_PORT=4001 SSH_HOST_PORT=3001 boot2docker init
```
