### PR TITLE
Adding brew update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [Frequently asked questions](doc/FAQ.md) for more details.
 
 #### OSX
 ```
+$ brew update
 $ brew install boot2docker
 ```
 


### PR DESCRIPTION
'brew install docker' failed on my system with 'Error: No available formula for boot2docker' - this was fixed by running brew update first. I've updated the instructions updated to reflect this.
