### PR TITLE
fix busy box dhcp bug which will result in an empty /etc/resolv.conf

### DIFF
--- a/rootfs/rootfs/usr/share/udhcpc/default.script
+++ b/rootfs/rootfs/usr/share/udhcpc/default.script
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# udhcpc script edited by Tim Riker <Tim@Rikers.org>
+
+[ -z "$1" ] && echo "Error: should be called from udhcpc" && exit 1
+
+RESOLV_CONF="/etc/resolv.conf"
+[ -n "$broadcast" ] && BROADCAST="broadcast $broadcast"
+[ -n "$subnet" ] && NETMASK="netmask $subnet"
+
+case "$1" in
+	deconfig)
+		/sbin/ifconfig $interface 0.0.0.0
+		;;
+
+	renew|bound)
+		/sbin/ifconfig $interface $ip $BROADCAST $NETMASK
+
+		if [ -n "$router" ] ; then
+			echo "deleting routers"
+			while route del default gw 0.0.0.0 dev $interface ; do
+				:
+			done
+
+			metric=0
+			for i in $router ; do
+				route add default gw $i dev $interface metric $((metric++))
+			done
+		fi
+
+		if [ -n "$dns" ] ; then
+			echo -n > $RESOLV_CONF
+		fi
+		[ -n "$domain" ] && echo search $domain >> $RESOLV_CONF
+		for i in $dns ; do
+			echo adding dns $i
+			echo nameserver $i >> $RESOLV_CONF
+		done
+		;;
+esac
+
+exit 0


### PR DESCRIPTION
bug in the configuration of busy box setting the /etc/resolv.conf to an empty value if there is no name server data coming from the DHCP Server for a second network interface #93 .

Please check if your tiny core linux already includes this fix:
https://bugs.busybox.net/show_bug.cgi?id=6788

```
/usr/share/udhcpc/default.script
@@ -28,7 +28,9 @@ case "$1" in
             done
         fi

-        echo -n > $RESOLV_CONF
+        if [ -n "$dns" ] ; then
+            echo -n > $RESOLV_CONF
+        fi
         [ -n "$domain" ] && echo search $domain >> $RESOLV_CONF
         for i in $dns ; do
             echo adding dns $i
```
