### PR TITLE
host only interface / dynamic IP with fixed hostname

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -188,7 +188,7 @@ mod_bashprofile() {
     grep -q "export DOCKER_HOST=" $HOME/.bash_profile
     if [[ "$?" == "1" ]]; then
         log "add 'export DOCKER_HOST=tcp://localhost:$DOCKER_PORT' to $HOME/.bash_profile"
-        sed -i.bak '/(export DOCKER_HOST=|docker.io)/d' $HOME/.bash_profile; 
+        sed -i .bak -E '/(export DOCKER_HOST=|docker.io)/d' $HOME/.bash_profile; 
         echo "\n### docker.io" >> $HOME/.bash_profile
         echo "export DOCKER_HOST=tcp://localhost:$DOCKER_PORT" >> $HOME/.bash_profile
         . $HOME/.bash_profile
@@ -203,7 +203,7 @@ mod_hosts() {
     if [[ "$?" == "1" ]]; then
         log "add '$BOOT2DOCKER_HOST_NAME $DOCKER_HOST_IP' to /etc/hosts"
 
-        MHD_HD_EXPORT_CMD="sudo sed -i.bak '/$BOOT2DOCKER_HOST_NAME/d' /etc/hosts; sudo echo \"$DOCKER_HOST_IP $BOOT2DOCKER_HOST_NAME\" >> /etc/hosts"
+        MHD_HD_EXPORT_CMD="sudo sed -i .bak -E '/$BOOT2DOCKER_HOST_NAME/d' /etc/hosts; sudo echo \"$DOCKER_HOST_IP $BOOT2DOCKER_HOST_NAME\" >> /etc/hosts"
         if [[ "$unamestr" == "Darwin" ]]; then
             MHD_HD_EXPORT_CMD="$MHD_HD_EXPORT_CMD; sudo killall -HUP mDNSResponder";
         fi


### PR DESCRIPTION
- creates a host only network in virtual box if not exist
- will ask to modify if a network exists which does not use the defined settings
- add a second interface to the VM with a host_only network - **needs #197 to work!**
- updates DOCKER_HOST in .bash_profile
- updates docker in /etc/hosts with the actual IP of the docker daemon on the host only network

**REQUIRES BASH** to work!

will ask for your docker vm user password if you not placed your public keys in the VM on every start to validate the current IP.

_this implements the requirements of #93 except for **_not offering a static IP**_ - this allows to have multiple VMs to use the same host only network and talk to each other._
