### PR TITLE
ssh suppress the waring Permanently added

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -162,7 +162,7 @@ init() {
 
 do_ssh() {
     is_installed || status
-    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $SSH_HOST_PORT docker@localhost $*
+    ssh -o StrictHostKeyChecking=no -o LogLevel=quiet -o UserKnownHostsFile=/dev/null -p $SSH_HOST_PORT docker@localhost $*
 }
 
 start() {


### PR DESCRIPTION
supress:
Warning: Permanently added '[localhost]:2022' (RSA) to the list of known hosts.
