### PR TITLE
Add "version" file to the root of the iso, too

### DIFF
--- a/rootfs/make_iso.sh
+++ b/rootfs/make_iso.sh
@@ -34,6 +34,8 @@ cd $ROOTFS
 find | cpio -o -H newc | xz -9 --format=lzma > /tmp/iso/boot/initrd.img
 cd -
 
+cp -v $ROOTFS/etc/version /tmp/iso/version
+
 # Make the ISO
 # Note: only "-isohybrid-mbr /..." is specific to xorriso.
 # It builds an image that can be used as an ISO *and* a disk image.


### PR DESCRIPTION
This makes it so that I can do something magic like `isoVersion=$(7z e -so "$iso" version 2>/dev/null)` given an arbitrary ISO to determine the b2d version it contains.
