### PR TITLE
Point to the standalone go-boot2docker repo

### DIFF
--- a/boot2docker.go
+++ b/boot2docker.go
@@ -1,5 +1,4 @@
 /*
 The Go port of boot2docker management script has been split into its own repo,
-please visit https://github.com/riobard/go-boot2docker for now before we find
-a permanent place for it.
+please visit https://github.com/boot2docker/boot2docker-cli.
 */


### PR DESCRIPTION
So people won't waste time sending pull requests here.
