### PR TITLE
rootfs: add google compute engine magic

### DIFF
--- a/rootfs/rootfs/bootsync.sh
+++ b/rootfs/rootfs/bootsync.sh
@@ -9,6 +9,11 @@
 # Automount a hard drive
 /etc/rc.d/automount
 
+if dmesg | grep Google; then
+  # Google Compute Engine magic
+  /etc/rc.d/google
+fi
+
 mkdir -p /var/lib/boot2docker/log
 
 #import settings from profile (or unset them)

--- a/rootfs/rootfs/etc/rc.d/google
+++ b/rootfs/rootfs/etc/rc.d/google
@@ -1,0 +1,5 @@
+ip link set eth0 up
+udhcpc
+ip route add 10.240.0.1 dev eth0
+ip route add default via 10.240.0.1 dev eth0
+ip addr show dev eth0 


### PR DESCRIPTION
note: the custom `iproute2` commands are needed because somehow `udhcpd` fails to set route propertly.

See:
https://www.irccloud.com/pastebin/H9L2GD0n
