### PR TITLE
Add NFS client for vagrant synced folder

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,8 @@ ENV TCZ_DEPS        iptables \
                     ncurses-common ncurses-terminfo ncurses ncurses-utils \
                     xz liblzma \
                     git expat2 libiconv libidn libgpg-error libgcrypt libssh2 \
-                    curl ntpclient
+                    curl ntpclient \
+                    nfs-utils rpcbind libtirpc
 
 
 RUN apt-get -y install  squashfs-tools \

--- a/rootfs/rootfs/bootsync.sh
+++ b/rootfs/rootfs/bootsync.sh
@@ -35,6 +35,9 @@ fi
 # Launch ACPId
 /etc/rc.d/acpid
 
+# Start NFS client
+/etc/rc.d/nfs-client
+
 # Launch Docker
 /etc/rc.d/docker
 

--- a/rootfs/rootfs/etc/rc.d/nfs-client
+++ b/rootfs/rootfs/etc/rc.d/nfs-client
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Start NFS client
+if [ -x /usr/local/etc/init.d/nfs-client ]; then
+  /usr/local/etc/init.d/nfs-client start
+fi


### PR DESCRIPTION
I created a vagrant box based on boot2docker v0.6.0 to support NFS synced folder,

but this PR would be better and faster than installing NFS client on boot in the box.

I'd be glad if it would be helpful for other cases, too.
