### PR TITLE
bootlocal.sh should not be in the background.

### DIFF
--- a/rootfs/rootfs/bootsync.sh
+++ b/rootfs/rootfs/bootsync.sh
@@ -40,5 +40,5 @@ fi
 
 # Allow local HD customisation
 if [ -e /var/lib/boot2docker/bootlocal.sh ]; then
-    /var/lib/boot2docker/bootlocal.sh &
+    /var/lib/boot2docker/bootlocal.sh
 fi


### PR DESCRIPTION
bootlocal.sh should not be in the background, because the next script may need completion of it.

e.g. vagrant provisioners
