### PR TITLE
Fix "mkdir : no such file or directory" error

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -12,7 +12,7 @@ start() {
     if [ -e /var/lib/docker/lxc-start-unconfined ]; then
         rm /var/lib/docker/lxc-start-unconfined
     fi
-    # TODO move this logfile out of /var/lib/docker
+    mkdir -p /var/lib/docker
     DOCKER_DIR=`readlink -f /var/lib/docker`
     /bin/dmesg | /bin/egrep '(VirtualBox|VMware|QEMU)' > /dev/null && EXPOSE_ALL="-H $DOCKER_HOST"
     TMPDIR=`readlink -f /tmp` /usr/local/bin/docker -d -D -g "$DOCKER_DIR" -H unix:// $EXPOSE_ALL > /var/lib/boot2docker/docker.log 2>&1 &


### PR DESCRIPTION
This was showing up because /var/lib/docker doesn't exist, so "readlink -f" was returning the empty string, which "docker -g" didn't take too kindly to.
