### PR TITLE
Fixed status() to properly capture "boot2docker-vm" expression...

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -233,23 +233,23 @@ is_installed() {
 }
 
 is_running() {
-    info | grep "State:\s\+running" > /dev/null
+    info | grep -E "State:[ ]+running" > /dev/null
 }
 
 is_paused() {
-    info | grep "State:\s\+paused" > /dev/null
+    info | grep -E "State:[ ]+paused" > /dev/null
 }
 
 is_suspended() {
-    info | grep "State:\s\+saved" > /dev/null
+    info | grep -E "State:[ ]+suspended" > /dev/null
 }
 
 is_stopped() {
-    info | grep "State:\s\+powered off" > /dev/null
+    info | grep -E "State:[ ]+powered off" > /dev/null
 }
 
 is_aborted() {
-    info | grep "State:\s\+aborted" > /dev/null
+    info | grep -E "State:[ ]+aborted" > /dev/null
 }
 
 status() {


### PR DESCRIPTION
...from VBoxManageManage|grep line by enclosing the space capture as a character class.
This works for both the default OS X grep 2.5x and GNU grep 2.16. 
This is preferable to asking users to upgrade their system tools on which other utilities might depend. 
