### PR TITLE
Reworked pause/save/suspend/resume logic. pause really pauses, save really saves, catch when a VM really doesn't exist vs. fell-through because of state-change

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -281,7 +281,7 @@ status() {
     else
         if is_installed;then
            log "$VM_NAME state unknown/in transition"
-	else
+        else
            log "$VM_NAME does not exist."
         fi 
         exit 1


### PR DESCRIPTION
Fixes for a few things that dent **LeastSurprise** that are related to, but separate from [767e69e](https://github.com/boot2docker/boot2docker/commit/767e69e03ec05b28680f569ba7806ad28acc0b6a) 

```
is_suspended() {
    info | grep -E "State:[ ]+suspended" > /dev/null
}
```

for example won't ever match because "suspended" isn't a valid VBoxManage state keyword, "paused" is.  
Also, If a VM is in the middle of a state change and someone runs

```
boot2docker status
```

 like right after calling 

```
boot2docker save
```

 , you can get back "vm does not exist" until the operation completes in the background a minute or two later. 
