### PR TITLE
Specify '-e lxc' to use the LXC driver

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -32,7 +32,7 @@ start() {
     # in case TMPDIR is a symlink, too, resolve it
     export TMPDIR="$(readlink -f "${TMPDIR:-/tmp}")"
     
-    /usr/local/bin/docker -d -D -g "$DOCKER_DIR" -H unix:// $EXTRA_ARGS > /var/lib/boot2docker/docker.log 2>&1 &
+    /usr/local/bin/docker -d -e lxc -D -g "$DOCKER_DIR" -H unix:// $EXTRA_ARGS > /var/lib/boot2docker/docker.log 2>&1 &
 }
 
 stop() {


### PR DESCRIPTION
I built boot2docker.iso with the latest commit and Docker v0.9.0.
Docker v0.9.0 in boot2docker-vm doesn't seem to work well.

Your team may be working for the new native driver of Docker v0.9.0,
but I patched a bit to use the LXC driver for now.
It seems to work fine so far.

I know it's not good for release, but just in case I'd like to put it here.
