### PR TITLE
Automated script

### DIFF
--- a/doc/KICKSTART.md
+++ b/doc/KICKSTART.md
@@ -1,0 +1,49 @@
+#Kickstarting boot2docker using automated_script
+
+#### Note! This guide assumes you have basic knowledge of how pxe booting works.
+
+Kickstarting can be done by giving boot2docker an arbitrary script to download and execute. Boot2docker has a user being logged in automatically. This user has a .bashrc that points to a global bashrc and we will be append a full path to script that reads /proc/cmdline. It uses the built-in curl to download the script and execute it. To achieve this you will give boot2docker a uri as a boot parameter in this format; `SCRIPT=http://path.to/script.sh`. Currently boot2docker has a timeout of 0 which means we will never be able to set this parameter upon boot. Instead we will use iPXE to set the parameter.
+
+
+The file being served from the dhcp server `undionly.kpxe` has an embedded script that tells it what to do next. [http://ipxe.org/embed#embedding_within_the_ipxe_binary](http://ipxe.org/embed#embedding_within_the_ipxe_binary)
+Booting from the following embedded script will try to chainload a script custom to its mac address. It will first try https and if it does not succeed; http.
+
+```
+#!ipxe
+dhcp
+
+chain https://192.168.3.3/execute/${mac:hexhyp} ||
+goto http
+
+:http
+chain http://192.168.3.3:4321/execute/${mac:hexhyp} ||
+goto solve
+
+:solve
+prompt --key 0x02 --timeout 2000 Press Ctrl-B for the iPXE command line... && shell ||
+exit 0
+```
+
+Lets say that it will chainload to the following script. The append variable is what shows up on /proc/cmdline. The vmlinuz64 and initrd.img is what is beeing booted from the network. You will need to extract these from the boot2docker iso and place it somewhere iPXE can reach it. 
+
+```
+#!ipxe
+
+set script http://path.to/script.sh
+set append loglevel=3 user=docker console=ttyS0 console=tty nomodeset norestore base script=${script}
+set kernel http://boot.home.local/agent/vmlinuz64
+set initrd http://boot.home.local/agent/initrd.img
+
+
+imgfree
+kernel ${kernel} ${append}
+initrd ${initrd}
+boot
+```
+
+Simplest example of a script beeing executed from the script parameter.
+
+```
+#!/bin/bash
+docker run -d pandrew/rethinkdb
+```

--- a/rootfs/rootfs/etc/profile.d/automated_script.sh
+++ b/rootfs/rootfs/etc/profile.d/automated_script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+script_cmdline ()
+{
+    local param
+    for param in $(< /proc/cmdline); do
+        case "${param}" in
+            script=*) echo "${param##*=}" ; return 0 ;;
+        esac
+    done
+}
+
+automated_script ()
+{
+    local script rt
+    script="$(script_cmdline)"
+    if [[ -n "${script}" && ! -x /tmp/startup_script ]]; then
+        if [[ "${script}" =~ ^http:// || "${script}" =~ ^ftp:// ]]; then
+            curl -fsL "${script}" -o /tmp/startup_script
+            rt=$?
+        else
+            cp "${script}" /tmp/startup_script
+            rt=$?
+        fi
+        if [[ ${rt} -eq 0 ]]; then
+            chmod +x /tmp/startup_script
+            /tmp/startup_script
+        fi
+    fi
+}
+
+if [[ $(tty) == "/dev/tty1" ]]; then
+    automated_script
+fi

--- a/rootfs/rootfs/usr/local/etc/bashrc
+++ b/rootfs/rootfs/usr/local/etc/bashrc
@@ -1,0 +1,33 @@
+HISTFILESIZE=500
+HISTCONTROL=ignoredups
+
+if [ "`id -u`" -eq 0 ]; then
+ HISTFILE=/root/.bash_history
+else
+ HISTFILE=$HOME/.bash_history
+fi
+
+if [ "`id -u`" -eq 0 ]; then
+ HOME=/root
+fi
+
+
+SHELL=/bin/bash
+ENV=$HOME/.bashrc
+
+
+export HISTFILE HISTFILESIZE HISTCONTROL TERM SHELL
+
+alias df='df -h'
+alias du='du -h'
+
+alias ls='ls -p'
+alias ll='ls -l'
+alias la='ls -la'
+
+# Avoid errors... use -f to skip confirmation.
+alias cp='cp -i'
+alias mv='mv -i'
+alias rm='rm -i'
+
+/etc/profile.d/automated_script.sh


### PR DESCRIPTION
automated_script gives boot2docker the functionality to parse the variable "script" from /proc/cmdline. This gives you the ability to send boot2docker a script to execute when the user docker has logged in using .bashrc as initial executor for the script.

It could be used to start containers, download and execute serf agents and more when using boot2docker with iPXE.
