### PR TITLE
introducing 'saved' state for status command

### DIFF
--- a/boot2docker
+++ b/boot2docker
@@ -242,6 +242,10 @@ is_paused() {
     info | grep -E "State:[ ]+paused" > /dev/null
 }
 
+is_saved() {
+    info | grep -E "State:[ ]+saved" > /dev/null
+}
+
 is_suspended() {
     info | grep -E "State:[ ]+suspended" > /dev/null
 }
@@ -260,6 +264,9 @@ status() {
         exit 0
     elif is_paused; then
         log "$VM_NAME is paused."
+        exit 1
+    elif is_saved; then
+        log "$VM_NAME is saved."
         exit 1
     elif is_suspended; then
         log "$VM_NAME is suspended."


### PR DESCRIPTION
> boot2docker status
> [2014-03-27 19:00:35] boot2docker-vm does not exist.
> 
> VBoxManage showvminfo boot2docker-vm|grep State State:           saved
> (since 2014-03-27T16:13:24.967000000)
