### PR TITLE
Update README.md: add link to OSX Puppet install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See [Frequently asked questions](doc/FAQ.md) for more details.
 $ brew update
 $ brew install boot2docker
 ```
+or [via Puppet](https://github.com/shaftoe/puppet-boot2docker)
 
 #### Linux/Unix (works also on OSX)
 ```


### PR DESCRIPTION
I see there's a brew install option that I think was not there when I wrote the puppet module, anyway I'm still using this option and maybe someone else could find it useful? Especially for those days in which mass deployment of boot2docker will be normal ;-)
