### PR TITLE
fix for docker rm issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ RUN curl -L -o /tcl_rootfs.gz $TCL_REPO_BASE/release/distribution_files/rootfs.g
 
 # Install the TCZ dependencies
 RUN for dep in $TCZ_DEPS; do \
+	echo "Download $TCL_REPO_BASE/tcz/$dep.tcz" &&\
         curl -L -o /tmp/$dep.tcz $TCL_REPO_BASE/tcz/$dep.tcz && \
         unsquashfs -f -d $ROOTFS /tmp/$dep.tcz && \
         rm -f /tmp/$dep.tcz ;\

--- a/rootfs/isolinux/isolinux.cfg
+++ b/rootfs/isolinux/isolinux.cfg
@@ -3,7 +3,7 @@ default boot2docker
 label boot2docker
 	kernel /boot/vmlinuz64
 	initrd /boot/initrd.img
-	append loglevel=3 user=docker console=ttyS0 console=tty0 nomodeset norestore base
+	append loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore base
 
 # see http://www.syslinux.org/wiki/index.php/SYSLINUX
 

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -31,9 +31,6 @@ start() {
         EXTRA_ARGS="$EXTRA_ARGS -s $DOCKER_STORAGE"
     fi
 
-    # can't pivot root on a ramdisk
-    export DOCKER_RAMDISK=please
-
     /usr/local/bin/docker -d -D -g "$DOCKER_DIR" -H unix:// $DOCKER_HOST $EXTRA_ARGS > /var/lib/boot2docker/docker.log 2>&1 &
 }
 


### PR DESCRIPTION
comparing the b2d/tcl init to the d2d one

http://git.tinycorelinux.net/index.cgi?url=Core-scripts.git/tree/init
vs
https://github.com/unclejack/debian2docker/blob/migrate_from_live-build/buildboot/init

and before I did anything more, I thought I'd see what the other
codepath (switch_root like d2d has...) did - so I added `noembed` and
https://github.com/dotcloud/docker/issues/4095 stops happening.

I have had some weird issues with tcz pkg's not being installed, but that seems to have evened out since. 
