### PR TITLE
README: add instructions for updating VM image

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ $ boot2docker init
 $ boot2docker up
 ```
 
+#### Upgrade the boot2docker vm image
+```
+$ boot2docker stop
+$ boot2docker download
+$ boot2docker up
+```
+
 
 ## Advanced usage
 


### PR DESCRIPTION
As mentioned in #348, document how to update boot2docker.iso in the readme.

It's a stopgap until boot2docker-cli is ready.
