### PR TITLE
Wait up to 3 seconds for the data volume to initialize

### DIFF
--- a/rootfs/isolinux/isolinux.cfg
+++ b/rootfs/isolinux/isolinux.cfg
@@ -4,7 +4,7 @@ default boot2docker
 label boot2docker
 	kernel /boot/vmlinuz64 com1=9600,8n1
 	initrd /boot/initrd.img
-	append loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore base
+	append loglevel=3 user=docker console=ttyS0 console=tty0 noembed nomodeset norestore waitusb=3:LABEL=boot2docker-data base
 
 # see http://www.syslinux.org/wiki/index.php/SYSLINUX
 


### PR DESCRIPTION
When storage hardware takes too long to initialize, the disk is not available at the time automount runs so the persistent boot2docker volume never gets mounted.  By adding a `waitusb` option to the kernel command line, we can pause the init sequence and allow the hardware initialization and discovery to complete.

I have repeatedly had this issue across multiple boot2docker releases when running under VMware.  Looking through the issues list, it seems others have had similar issues:

boot2docker/boot2docker#390
boot2docker/boot2docker#26
boot2docker/boot2docker#51

While many of those were closed, I'm not sure all were resolved.

To help address this issue, I propose we add `waitusb=3:LABEL=boot2docker-data` to the kernel command line.  That option causes  Tiny Core Linux to pause until a volume with the `boot2docker-data` label is availalbe or 3 seconds have passed.  If a disk is available with the expected volume label, we shouldn't see an elongated boot time; when a volume with the expected label does not exist (boot without a persistent file system, for example), we will see a 3 second delay in the boot sequence.  This seems like a good tradeoff to me.
