### PR TITLE
#357 Wait for eth0 to be up before starting docker - borrow existing code

### DIFF
--- a/rootfs/rootfs/etc/rc.d/docker
+++ b/rootfs/rootfs/etc/rc.d/docker
@@ -1,3 +1,24 @@
 #!/bin/sh
 
+# dhcp.sh runs udhcpc async, so it exits before network is up
+wait4Server() {
+	/etc/init.d/dhcp.sh
+	SERVER=$1 ; NOPING=$2 ; CNT=0
+	if [ "$NOPING" == "1" ] ; then
+		until ifconfig eth0 | grep -q Bcast
+		do
+			[ $((CNT++)) -gt 60 ] && break || sleep 1
+		done
+		sleep 1
+	else
+		until ping -c 1 $SERVER >/dev/null 2>&1     
+		do
+			[ $((CNT++)) -gt 60 ] && break || sleep 1
+		done
+	fi
+	DHCP_RAN=1
+}
+
+wait4Server 10.0.2.3 1
+
 /usr/local/etc/init.d/docker start


### PR DESCRIPTION
Took code from tc-config which waits for dhcp to complete.  This version doesn't ping, but you could ping the DNS server (10.0.2.3) which I think only exists if you have nat dns host resolver enabled or 10.0.2.2 (does that always exist?)
This, tied with a change in boot2docker-cli which would create the VM with the nat dns host resolver (that I haven't yet codified) will make sure dns for containers is the same as the host dns.  I tested this manually :(
