### PR TITLE
ensure the swap is enabled on first boot

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -26,6 +26,7 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
             (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD
             (echo t; echo 82) | fdisk $UNPARTITIONED_HD
             mkswap "${UNPARTITIONED_HD}2"
+            swapon "${UNPARTITIONED_HD}2"
             # Add the data partition
             (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
             BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`


### PR DESCRIPTION
The swap partition created on the "boot2docker, please format-me" disks is not enabled on the very first boot (despite being in fstab). This does the job, although there might be a nicer solution utilizing the TC init process.
