### PR TITLE
file either in ../syslinux/ or ../syslinux/mbr depending on jessie version

### DIFF
--- a/rootfs/make_iso.sh
+++ b/rootfs/make_iso.sh
@@ -34,5 +34,5 @@ cp -v $ROOTFS/etc/version /tmp/iso/version
 xorriso -as mkisofs \
     -l -J -R -V boot2docker -no-emul-boot -boot-load-size 4 -boot-info-table \
     -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
-    -isohybrid-mbr /usr/lib/syslinux/isohdpfx.bin \
+    -isohybrid-mbr `find /usr/lib/syslinux/ -name isohdppx.bin` \
     -o /boot2docker.iso /tmp/iso


### PR DESCRIPTION
See #440. Since `debian:jessie` is a mutable reference and the build instructions/script doesn't explicitly tell to `docker pull` the base, we should probably support both base images and use a `find` rather than an hardcoded path.
