### PR TITLE
Fix regression - ext4 partition not created on "boot2docker, please format-me" disks

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -26,11 +26,11 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
             (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD
             (echo t; echo 82) | fdisk $UNPARTITIONED_HD
             mkswap "${UNPARTITIONED_HD}2"
-            swapon "${UNPARTITIONED_HD}2"
             # Add the data partition
             (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
             BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
             mkfs.ext4 -L $LABEL $BOOT2DOCKER_DATA
+            swapon "${UNPARTITIONED_HD}2"
         fi
     else
         # Pick the first ext4 as a fallback


### PR DESCRIPTION
It turns out that https://github.com/boot2docker/boot2docker/pull/428 had the (_very_ annoying) side-effect of breaking the formatting of /dev/sda1, as `mkfs.ext4` was silently failing, leaving the guest without any persistent storage... Very sorry for that.
