### PR TITLE
Fix the system clock sync

### DIFF
--- a/rootfs/rootfs/etc/rc.d/ntpclient
+++ b/rootfs/rootfs/etc/rc.d/ntpclient
@@ -1,8 +1,17 @@
 #!/bin/sh
 
 if [ -n "$NTP_SERVER" ]; then
-	echo "running ntpclient -s -h $NTP_SERVER in background" > /var/lib/boot2docker/log/ntpclient.log 2>&1 
-	/usr/local/bin/ntpclient -s -h $NTP_SERVER >> /var/lib/boot2docker/log/ntpclient.log 2>&1 
+    # Wait on the network
+    while ! ping -c 1 $NTP_SERVER; do
+        sleep 1
+    done
+
+    # First, set the system time to the NTP server
+    echo "running ntpclient -s -g 1000000 -h $NTP_SERVER" > /var/lib/boot2docker/log/ntpclient.log 2>&1
+    /usr/local/bin/ntpclient -s -g 1000000 -h $NTP_SERVER >> /var/lib/boot2docker/log/ntpclient.log 2>&1
+    # Then lock it
+    echo "running ntpclient -l -h $NTP_SERVER in the background" >> /var/lib/boot2docker/log/ntpclient.log 2>&1
+    /usr/local/bin/ntpclient -l -h $NTP_SERVER & >> /var/lib/boot2docker/log/ntpclient.log 2>&1
 else
-	echo "Skipping ntpclient" > /var/lib/boot2docker/log/ntpclient.log 2>&1 
+    echo "Skipping ntpclient" > /var/lib/boot2docker/log/ntpclient.log 2>&1
 fi


### PR DESCRIPTION
The current command isn't working (mostly because the network might not be up at that moment), and also it doesn't lock the system clock, so if the host sleeps, for instance, we'll have time discrepancies.

This fixes that.
