### PR TITLE
Output from "ping" is distracting and irrelevant

### DIFF
--- a/rootfs/rootfs/etc/rc.d/ntpclient
+++ b/rootfs/rootfs/etc/rc.d/ntpclient
@@ -2,7 +2,7 @@
 
 if [ -n "$NTP_SERVER" ]; then
     # Wait on the network
-    while ! ping -c 1 $NTP_SERVER; do
+    while ! ping -c 1 $NTP_SERVER &> /dev/null; do
         sleep 1
     done
 


### PR DESCRIPTION
... especially on QEMU, where we can't ping out, so it just prints to the console endlessly

As mentioned on #468
