### PR TITLE
It needs contents under /tmp to execute tce-load at runtime.

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -77,8 +77,7 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
 
     # Make sure /tmp is on the disk too too
     rm -rf /mnt/$PARTNAME/tmp || true
-    rm -rf /tmp || true
-    mkdir -p /mnt/$PARTNAME/tmp
+    mv /tmp /mnt/$PARTNAME/tmp
     ln -fs /mnt/$PARTNAME/tmp /tmp
 
     if [ -e "/userdata.tar" ]; then


### PR DESCRIPTION
And also /mnt/$PARTNAME/tmp should be writable for anyone just like /tmp was.
