### PR TITLE
Enable use of boot2docker.local hostname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ ENV TCZ_DEPS        iptables \
                     xz liblzma \
                     git expat2 libiconv libidn libgpg-error libgcrypt libssh2 \
                     nfs-utils tcp_wrappers portmap rpcbind libtirpc \
-                    curl ntpclient
+                    curl ntpclient \
+                    avahi libavahi dbus expat2 gcc_libs glib2 libffi libdaemon nss-mdns
 
 # Make the ROOTFS
 RUN mkdir -p $ROOTFS

--- a/rootfs/rootfs/bootscript.sh
+++ b/rootfs/rootfs/bootscript.sh
@@ -45,6 +45,9 @@ fi
 # Launch ACPId
 /etc/rc.d/acpid
 
+# Launch Avahi
+/etc/rc.d/avahi
+
 echo "-------------------"
 date
 #maybe the links will be up by now - trouble is, on some setups, they may never happen, so we can't just wait until they are

--- a/rootfs/rootfs/etc/rc.d/avahi
+++ b/rootfs/rootfs/etc/rc.d/avahi
@@ -1,0 +1,2 @@
+# Launch Avahi
+/usr/local/etc/init.d/avahi start


### PR DESCRIPTION
This patch enables the use of the `boot2docker.local` hostname to access the local `boot2docker-vm` instance from the host.

Adding Avahi and its dependencies to the image to support this functionality adds about 2 megabytes to `boot2docker.iso`.
