### PR TITLE
Turn on TLS and cert generation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ small ~24MB download and boots in ~5s (YMMV).
 * Container persistence via disk automount on `/var/lib/docker`
 * SSH keys persistence via disk automount
 
-> **Note:** Boot2Docker uses port **2375**, the [registered IANA Docker
+> **Note:** Boot2Docker uses port **2376**, the [registered IANA Docker SSL
 > port](http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=docker)
 
 ## Installation
@@ -112,6 +112,16 @@ ip`).
 
 If you want to share container ports with other computers on your LAN, you will
 need to set up [NAT adaptor based port forwarding](doc/WORKAROUNDS.md).
+
+#### TLS support
+
+By default, `boot2docker` runs `docker` with TLS enabled. It auto-generates
+certificates and stores them in `/home/docker/.docker` inside the VM. The
+`boot2docker up` command will copy them to `~/.boot2docker/certs` on the
+host machine once the VM has started, and output the correct values for
+the `DOCKER_CERT_PATH` and `DOCKER_TLS_VERIFY` environment variables.
+
+`$(boot2docker shellinit)` will also set them correctly.
 
 #### Folder sharing
 

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -6,7 +6,7 @@
 test -f '/var/lib/boot2docker/profile' && . '/var/lib/boot2docker/profile'
 
 : ${DOCKER_HOST:='-H tcp://0.0.0.0:2375'}
-: ${DOCKER_TLS:=''}
+: ${DOCKER_TLS:=auto}
 : ${DOCKER_STORAGE:=auto}
 : ${DOCKER_DIR:=/var/lib/docker}
 : ${DOCKER_ULIMITS:=1048576}


### PR DESCRIPTION
Waiting on https://github.com/docker/docker/pull/8503, https://github.com/boot2docker/boot2docker-cli/pull/269
