### PR TITLE
Generate certs and enable TLS

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -6,7 +6,7 @@
 test -f '/var/lib/boot2docker/profile' && . '/var/lib/boot2docker/profile'
 
 : ${DOCKER_HOST:='-H tcp://0.0.0.0:2375'}
-: ${DOCKER_TLS:=''}
+: ${DOCKER_TLS:=auto}
 : ${DOCKER_STORAGE:=auto}
 : ${DOCKER_DIR:=/var/lib/docker}
 : ${DOCKER_ULIMITS:=1048576}


### PR DESCRIPTION
In preparation for 1.3.0 release, generate certs and enable TLS
by default.

Signed-off-by: Ben Firshman ben@firshman.co.uk
