### PR TITLE
Updated .md documentation files and scripts to location in /opt for boot...

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [Frequently asked questions](doc/FAQ.md) for more details.
 
 #### Boot script log
 
-The bootup script output is logged to `/boot.log`, so you can see (and
+The bootup script output is logged to `/var/log/boot2docker.log`, so you can see (and
 potentially debug) what happens. Note that this is not persistent between boots
 because we're logging from before the persistence partition is mounted (and it
 may not exist at all).

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -40,10 +40,10 @@ that doesn't exist, it will pick the first ``ext4`` partition listed by ``blkid`
 **Local Customisation (with persistent partition)**
 
 If you have a persistence partition, you can make customisations that are run at
-the end of the boot initialisation in the ``/var/lib/boot2docker/bootlocal.sh`` file.
+the end of the boot initialisation in the ``/opt/bootlocal.sh`` file.
 
 You can also set variables that will be used during the boot initialisation (after
-the automount) by setting them in `/var/lib/boot2docker/profile`
+the automount) by setting them in `/opt/profile`
 
 For example, to download ``pipework``, install its pre-requisites (which you can
 download using ``tce-load -w package.tcz``), and then start a container:

--- a/rootfs/rootfs/bootscript.sh
+++ b/rootfs/rootfs/bootscript.sh
@@ -17,7 +17,7 @@ mkdir -p /var/lib/boot2docker/log
 
 #import settings from profile (or unset them)
 export NTP_SERVER=pool.ntp.org
-test -f "/var/lib/boot2docker/profile" && . "/var/lib/boot2docker/profile"
+test -f "/opt/profile" && . "/opt/profile"
 
 # set the hostname
 /etc/rc.d/hostname
@@ -65,8 +65,8 @@ if [ -e /var/lib/boot2docker/bootsync.sh ]; then
 fi
 
 # Allow local HD customisation
-if [ -e /var/lib/boot2docker/bootlocal.sh ]; then
-    /var/lib/boot2docker/bootlocal.sh > /var/log/bootlocal.log 2>&1 &
+if [ -e /opt/bootlocal.sh ]; then
+    /opt/bootlocal.sh > /var/log/bootlocal.log 2>&1 &
 fi
 
 # Execute automated_script


### PR DESCRIPTION
...local.sh and profile

The documentation is not confirming the current released version: the bootscripts.sh resides in /opt instead of in /var/lib/boot2docker. The script further checks for bootlocal.sh and profile, for making local modifications, but also does so in the wrong location. I updated the documentation and the script to use /opt.
