### PR TITLE
boot2docker does not use --registry-mirror option available with docker ...

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -72,12 +72,14 @@ following to ``/var/lib/boot2docker/profile``:
 EXTRA_ARGS="--dns 192.168.1.2"
 ```
 
-Another example: if you want to configure the Docker daemon to make profit of a registry mirror (docker >= 1.3.0), add the following to ``/var/lib/boot2docker/profile``:
+Another example: if you want to configure the Docker daemon to make profit of registry mirrors (docker >= 1.3.0), add the following to ``/var/lib/boot2docker/profile``:
 
 ```
 DOCKER_REG_MIRROR=http://<private_registry_host>:<private_registry_port>
 # ex: http://localhost:5000
 # http or https depending on your registry setup
+# several mirrors can be defined, separate them by a comma :
+DOCKER_REG_MIRROR=mir1,mir2
 ```
 Please visit [Run a registry mirror](https://github.com/docker/docker/blob/master/docs/sources/articles/registry_mirror.md) for more information on how-to setup to activate this feature.
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -72,6 +72,15 @@ following to ``/var/lib/boot2docker/profile``:
 EXTRA_ARGS="--dns 192.168.1.2"
 ```
 
+Another example: if you want to configure the Docker daemon to make profit of a registry mirror (docker >= 1.3.0), add the following to ``/var/lib/boot2docker/profile``:
+
+```
+DOCKER_REG_MIRROR=http://<private_registry_host>:<private_registry_port>
+# ex: http://localhost:5000
+# http or https depending on your registry setup
+```
+Please visit [Run a registry mirror](https://github.com/docker/docker/blob/master/docs/sources/articles/registry_mirror.md) for more information on how-to setup to activate this feature.
+
 **What is the development process**
 
 We are implementing the same process as [Docker merge approval](

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -11,7 +11,7 @@ test -f '/var/lib/boot2docker/profile' && . '/var/lib/boot2docker/profile'
 : ${DOCKER_DIR:=/var/lib/docker}
 : ${DOCKER_ULIMITS:=1048576}
 : ${DOCKER_LOGFILE:=/var/lib/boot2docker/docker.log}
-: ${DOCKER_REG_MIRROR:=no}
+: ${DOCKER_REG_MIRROR:=none}
 
 : ${CERTDIR:=/var/lib/boot2docker/tls/}
 : ${CACERT:="${CERTDIR}ca.pem"}
@@ -90,8 +90,11 @@ start() {
         EXTRA_ARGS="$EXTRA_ARGS -s $DOCKER_STORAGE"
     fi
 
-    if [ "$DOCKER_REG_MIRROR" != 'no' ]; then
-        EXTRA_ARGS="$EXTRA_ARGS --registry-mirror=$DOCKER_REG_MIRROR"
+    if [ "$DOCKER_REG_MIRROR" != 'none' ]; then
+        # several registry mirrors can be defined, declaring them separately
+        for mirror in $(echo $DOCKER_REG_MIRROR | sed "s/,/ /g"); do
+            EXTRA_ARGS="$EXTRA_ARGS --registry-mirror=$mirror"
+        done
     fi
 
     # Increasing the number of open files and processes by docker

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -11,6 +11,7 @@ test -f '/var/lib/boot2docker/profile' && . '/var/lib/boot2docker/profile'
 : ${DOCKER_DIR:=/var/lib/docker}
 : ${DOCKER_ULIMITS:=1048576}
 : ${DOCKER_LOGFILE:=/var/lib/boot2docker/docker.log}
+: ${DOCKER_REG_MIRROR:=no}
 
 : ${CERTDIR:=/var/lib/boot2docker/tls/}
 : ${CACERT:="${CERTDIR}ca.pem"}
@@ -87,6 +88,10 @@ start() {
     if [ "$DOCKER_STORAGE" != 'auto' ]; then
         # in the general case, let's trust Docker to "do the right thing"
         EXTRA_ARGS="$EXTRA_ARGS -s $DOCKER_STORAGE"
+    fi
+
+    if [ "$DOCKER_REG_MIRROR" != 'no' ]; then
+        EXTRA_ARGS="$EXTRA_ARGS --registry-mirror=$DOCKER_REG_MIRROR"
     fi
 
     # Increasing the number of open files and processes by docker


### PR DESCRIPTION
...>= v1.3.0 #602

Added variable DOCKER_REG_MIRROR to detect and activate registry-mirror for Docker daemon
To be used via persistent partition :
echo "DOCKER_REG_MIRROR=http://<localregistry>" >> /var/lib/boot2docker/profile
