### PR TITLE
Adding FAQ for automatically setting environment variables

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -84,3 +84,7 @@ There are two parts of Boot2Docker: the ISO image, and the `boot2docker` managem
 tool to set up and mange a VM. The management tool only works with VirtualBox,
 but the ISO image is designed to also be used with physical hardware. There
 are no plans to make separate ISO images for different configurations.
+
+**Can boot2docker set its environment variables automatically for me?**
+
+Boot2Docker doesn't do this, but other people have written scripts that do. [boot2docker-autoset](https://github.com/atbaker/boot2docker-autoset) is one example.


### PR DESCRIPTION
I really appreciate how easy Boot2Docker is to use, and how you all stay on top of the latest Docker releases.

Boot2Docker is correct to not force users to automatically set the environment variables for Docker clients. I work with Docker and boot2docker often, though, so I wrote a small script this afternoon that does automatically set the Boot2Docker environment variables: https://github.com/atbaker/boot2docker-autoset

This PR adds an FAQ about automatically setting the environment variables and points users to the boot2docker-autoset repo.

boot2docker-autoset is a _very_ small script, but I figured including it in the FAQs might help other devs who want to automatically set the Boot2Docker environment variables in each session.

Thanks!
