### PR TITLE
bump kernel to 3.16.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get -y install  unzip \
                         pkg-config \
                         p7zip-full
 
-ENV KERNEL_VERSION  3.16.4
+ENV KERNEL_VERSION  3.16.7
 ENV AUFS_BRANCH     aufs3.16
 
 # Fetch the kernel sources

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ small ~24MB download and boots in ~5s (YMMV).
 
 ## Features
 
-* Kernel 3.16.4 with AUFS, Docker v1.3.0 - using libcontainer
+* Kernel 3.16.7 with AUFS, Docker v1.3.0 - using libcontainer
 * Container persistence via disk automount on `/var/lib/docker`
 * SSH keys persistence via disk automount
 

--- a/kernel_config
+++ b/kernel_config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 3.16.4 Kernel Configuration
+# Linux/x86 3.16.7 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y


### PR DESCRIPTION
This PR bumps the kernel to 3.16.7. This is going to be the last 3.16 kernel.
