### PR TITLE
Update FAQ.md

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -5,7 +5,7 @@ FAQ
 
 * CPU Cores: same as host (physical, not logical)
 * 40gb HDD (auto-initialized at first boot)
-* 1gb memory
+* 2GB memory
 * Autoboots to Boot2Docker
 * `virtio` high performance networking
 * NAT networked (Docker `2375->2375` and SSH `22->2022` are forwarded to the host)


### PR DESCRIPTION
Latest version of boot2docker appears to run with 2048 megabytes of memory.

$ boot2docker info
{
    "Name": "boot2docker-vm",
    "UUID": "c58b1294-e2c6-4dc0-b825-5657eb5eca26",
    "Iso": "/Users/robin/.boot2docker/boot2docker.iso",
    "State": "running",
    "CPUs": 8,
    "Memory": 2048,
    "VRAM": 8,
    "CfgFile": "/Users/robin/VirtualBox VMs/boot2docker-vm/boot2docker-vm.vbox",
    "BaseFolder": "/Users/robin/VirtualBox VMs/boot2docker-vm",
    "OSType": "",
    "Flag": 0,
    "BootOrder": null,
    "DockerPort": 0,
    "SSHPort": 2022,
    "SerialFile": "/Users/robin/.boot2docker/boot2docker-vm.sock"
}
