### PR TITLE
Allow auto disk formatting if there's no magic string (blank disk)

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -9,7 +9,7 @@ BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABEL`
 echo $BOOT2DOCKER_DATA
 if [ ! -n "$BOOT2DOCKER_DATA" ]; then
     echo "Is the disk unpartitioned?, test for the 'boot2docker format-me' string"
-    
+
     # Is the disk unpartitioned?, test for the 'boot2docker format-me' string
     UNPARTITIONED_HD=`fdisk -l | grep "doesn't contain a valid partition table" | head -n 1 | sed 's/Disk \(.*\) doesn.*/\1/'`
 
@@ -20,20 +20,21 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
         if [ "$HEADER" = "$MAGIC" ]; then
             # save the preload userdata.tar file
             dd if=$UNPARTITIONED_HD of=/userdata.tar bs=1 count=4096 2>/dev/null
-            # Create the partition, format it and then mount it
-            echo "NEW boot2docker managed disk image ($UNPARTITIONED_HD): formatting it for use"
-            echo "NEW boot2docker managed disk image ($UNPARTITIONED_HD): formatting it for use" > /home/docker/log.log
-
-            # Add a swap partition (so Docker doesn't complain about it missing)
-            (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD
-            (echo t; echo 82) | fdisk $UNPARTITIONED_HD
-            mkswap "${UNPARTITIONED_HD}2"
-            # Add the data partition
-            (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
-            BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
-            mkfs.ext4 -L $LABEL $BOOT2DOCKER_DATA
-            swapon "${UNPARTITIONED_HD}2"
         fi
+
+        # Create the partition, format it and then mount it
+        echo "NEW boot2docker managed disk image ($UNPARTITIONED_HD): formatting it for use"
+        echo "NEW boot2docker managed disk image ($UNPARTITIONED_HD): formatting it for use" > /home/docker/log.log
+
+        # Add a swap partition (so Docker doesn't complain about it missing)
+        (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD
+        (echo t; echo 82) | fdisk $UNPARTITIONED_HD
+        mkswap "${UNPARTITIONED_HD}2"
+        # Add the data partition
+        (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
+        BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
+        mkfs.ext4 -L $LABEL $BOOT2DOCKER_DATA
+        swapon "${UNPARTITIONED_HD}2"
     else
         # Pick the first ext4 as a fallback
         # TODO: mount all Linux partitions and look for a /var/lib/docker...
@@ -83,7 +84,7 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
     if [ -e "/userdata.tar" ]; then
         mv /userdata.tar /var/lib/boot2docker/
     fi
-    
+
     ls -l /mnt/$PARTNAME
 fi
 # /etc dirs are initialised from /usr/local, to allow the user/admin to customise


### PR DESCRIPTION
In the event where there's no userdata.tar, automount will still format the disk.
