### PR TITLE
Updates the VBOX version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ RUN curl -L -o $ROOTFS/usr/local/bin/generate_cert https://github.com/SvenDowide
 # Build VBox guest additions
 # For future reference, we have to use x86 versions of several of these bits because TCL doesn't support ELFCLASS64
 # (... and we can't use VBoxControl or VBoxService at all because of this)
-ENV VBOX_VERSION 4.3.18
+ENV VBOX_VERSION 4.3.20
 RUN mkdir -p /vboxguest && \
     cd /vboxguest && \
     \


### PR DESCRIPTION
Fixes a bug preventing folder share throw VirtualBox Guest Additions.
The virtual box provided for windows is the 4.3.20 and it doesn't work with guest additions 4.3.18.