### PR TITLE
Launch docker after supplemental bootscripts

### DIFF
--- a/rootfs/rootfs/bootscript.sh
+++ b/rootfs/rootfs/bootscript.sh
@@ -59,9 +59,6 @@ date
 ip a
 echo "-------------------"
 
-# Launch Docker
-/etc/rc.d/docker
-
 # Allow local bootsync.sh customisation
 if [ -e /var/lib/boot2docker/bootsync.sh ]; then
     /var/lib/boot2docker/bootsync.sh
@@ -71,6 +68,9 @@ fi
 if [ -e /var/lib/boot2docker/bootlocal.sh ]; then
     /var/lib/boot2docker/bootlocal.sh > /var/log/bootlocal.log 2>&1 &
 fi
+
+# Launch Docker
+/etc/rc.d/docker
 
 # Execute automated_script
 # disabled - this script was written assuming bash, which we no longer have.


### PR DESCRIPTION
This is a bit of an edge case, but the change shouldn't affect regular behaviour.

### Use case:

Because of the limited size of the disk, I'd like to store docker images outside of the VM through a shared folder.

I can do that by setting the "Path to use as the root of the Docker runtime"; */var/lib/boot2docker/profile*:

`EXTRA_ARGS='-g /Users/somewhere/docker'`

And this works because `/etc/rc.d/automount` runs already on line 10 exposing the **/Users** directory. However, afaik, there's really no way to get it working, if the shared folder goes elsewhere. (External disk etc.)

`EXTRA_ARGS='-g /var/lib/boot2docker/docker_storage'` (Mounted outside from e.g. /Volume/something)

This is because the docker daemon starts up before it's possible to mount something in the folder of the docker root.

With this change however, it would be possible to add a line like so, to `/opt/bootlocal.sh` and have it available to docker:

`sudo mount -t vboxsf -o uid=1000,gid=50 docker /var/lib/boot2docker/docker_storage`