### PR TITLE
Bump the kernel to 3.18.9 (and AUFS patches to latest 3.18.1+)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get -y install  unzip \
                         p7zip-full
 
 # https://www.kernel.org/
-ENV KERNEL_VERSION  3.18.7
+ENV KERNEL_VERSION  3.18.9
 # http://sourceforge.net/p/aufs/aufs3-standalone/ref/master/branches/
 ENV AUFS_BRANCH     aufs3.18.1+
-ENV AUFS_COMMIT     f9f16b996df1651c5ab19bd6e6101310e3659c76
+ENV AUFS_COMMIT     30b7ab5cba58c1eefdf55f00b9a1c8979fa30e1d
 # we use AUFS_COMMIT to get stronger repeatability guarantees
 
 # Fetch the kernel sources
@@ -131,7 +131,7 @@ RUN curl -L -o $ROOTFS/usr/local/bin/generate_cert https://github.com/SvenDowide
 # Build VBox guest additions
 # For future reference, we have to use x86 versions of several of these bits because TCL doesn't support ELFCLASS64
 # (... and we can't use VBoxControl or VBoxService at all because of this)
-ENV VBOX_VERSION 4.3.20
+ENV VBOX_VERSION 4.3.26
 RUN mkdir -p /vboxguest && \
     cd /vboxguest && \
     \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ small ~24MB download and boots in ~5s (YMMV).
 
 ## Features
 
-* Kernel 3.18.5 with AUFS, Docker v1.5.0 - using libcontainer
+* Kernel 3.18.9 with AUFS, Docker v1.5.0 - using libcontainer
 * Container persistence via disk automount on `/var/lib/docker`
 * SSH keys persistence via disk automount
 


### PR DESCRIPTION
Tested and verified to boot up, initialize Docker on AUFS, and run containers properly. :+1:

```console
docker@boot2docker:~$ docker info
Containers: 0
Images: 0
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Backing Filesystem: tmpfs
 Dirs: 0
Execution Driver: native-0.2
Kernel Version: 3.18.9-tinycore64
Operating System: Boot2Docker 1.5.0 (TCL 5.4); master : 175488c - Mon Mar  9 16:17:41 UTC 2015
CPUs: 1
Total Memory: 3.868 GiB
Name: boot2docker
ID: 34TC:BZMZ:5D6H:YFZD:TVBQ:RZG7:V2QT:7PXM:6KTJ:P7MM:TX46:G5A5
Debug mode (server): true
Debug mode (client): false
Fds: 11
Goroutines: 15
EventsListeners: 0
Init Path: /usr/local/bin/docker
Docker Root Dir: /var/lib/docker
docker@boot2docker:~$ docker run --rm hello-world
Unable to find image 'hello-world:latest' locally
511136ea3c5a: Pull complete 
31cbccb51277: Pull complete 
e45a5af57b00: Pull complete 
hello-world:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
Status: Downloaded newer image for hello-world:latest
Hello from Docker.
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (Assuming it was not already locally available.)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

For more examples and ideas, visit:
 http://docs.docker.com/userguide/
docker@boot2docker:~$ docker run -it --rm busybox
Unable to find image 'busybox:latest' locally
df7546f9f060: Pull complete 
ea13149945cb: Pull complete 
4986bf8c1536: Pull complete 
511136ea3c5a: Already exists 
busybox:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
Status: Downloaded newer image for busybox:latest
/ # ping google.com
PING google.com (216.58.217.206): 56 data bytes
qemu: terminating on signal 2
```