### PR TITLE
support interfaces with aliases

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -29,10 +29,10 @@ start() {
     if [ "$DOCKER_TLS" != "no" ]; then
         CERTHOSTNAMES="$(hostname -s),$(hostname -i)"
         for interface in ${CERT_INTERFACES}; do
-          IP=$(ip addr show ${interface} |sed -nEe 's/^[ \t]*inet[ \t]*([0-9.]+)\/.*$/\1/p')
-          if [ "$IP" != "" ]; then
-            CERTHOSTNAMES="$CERTHOSTNAMES,$IP"
-          fi
+          IPS=$(ip addr show ${interface} |sed -nEe 's/^[ \t]*inet[ \t]*([0-9.]+)\/.*$/\1/p')
+          for ip in $IPS; do
+            CERTHOSTNAMES="$CERTHOSTNAMES,$ip"
+          done
         done
         echo "Need TLS certs for $CERTHOSTNAMES"
         echo "-------------------"


### PR DESCRIPTION
the cert generation script currently doesn't support interfaces with multiple IPs assigned.