### PR TITLE
Quiet down build error messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV AUFS_COMMIT     30b7ab5cba58c1eefdf55f00b9a1c8979fa30e1d
 # we use AUFS_COMMIT to get stronger repeatability guarantees
 
 # Fetch the kernel sources
-RUN curl --retry 10 https://www.kernel.org/pub/linux/kernel/v3.x/linux-$KERNEL_VERSION.tar.xz | tar -C / -xJ && \
+RUN curl --silent --retry 10 https://www.kernel.org/pub/linux/kernel/v3.x/linux-$KERNEL_VERSION.tar.xz | tar -C / -xJ && \
     mv /linux-$KERNEL_VERSION /linux-kernel
 
 # Download AUFS and apply patches and files, then remove it

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
                         syslinux \
                         automake \
                         pkg-config \
-                        p7zip-full
+                        p7zip-full && \
+    rm -rf /var/cache/apt /var/lib/apt
 
 # https://www.kernel.org/
 ENV KERNEL_VERSION  3.18.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian:wheezy
 MAINTAINER Steeve Morin "steeve.morin@gmail.com"
 
-RUN apt-get update && apt-get -y install  unzip \
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update && apt-get -y install  unzip \
                         xz-utils \
                         curl \
                         bc \


### PR DESCRIPTION
If `apt-get` is not informed it is running "headless", it tries to spawn confirmation dialogs as it goes through to configure the packages.

This change switches `apt-get` to headless, which suppresses almost all of the red text.

While I was in there, leaving the stuff that `apt-get update` pulls down in the docker layer is only increasing its disk size, so I asked docker to remove those files after it was done with them.

And, in a similar vein to removing the red text from `apt-get`, there was no meaningful information conveyed from `curl`, only red text since curl writes messages to stderr. I can easily see that commit being controversial, so just let me know if you don't agree with that change.