### PR TITLE
NFS support instructions added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ partition, and install an MBR.
   
     ```
     # BOOT2-DOCKER-BEGIN
+    # 192.168.59.103 is the boot2docker VM IP which you can find by running 'boot2docker ip' on the host machine
     /Users 192.168.59.103 -alldirs -mapall=501:20
     # BOOT2-DOCKER-END
     ```
@@ -298,6 +299,7 @@ partition, and install an MBR.
     #!/bin/sh
     sudo umount /Users
     sudo /usr/local/etc/init.d/nfs-client start
+    # 192.168.59.3 is the Host only adapter IP
     sudo mount -t nfs -o rw --actimeo=2 192.168.59.3:/Users /Users
     ```
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ partition, and install an MBR.
   - Then add the following content to that script.
 
     ```
-    #/bin/bash
+    #!/bin/sh
     sudo umount /Users
     sudo /usr/local/etc/init.d/nfs-client start
     sudo mount -t nfs -o rw --actimeo=2 192.168.59.3:/Users /Users

--- a/README.md
+++ b/README.md
@@ -266,6 +266,55 @@ To 'install' the ISO onto an SD card, USB-Stick or even empty hard disk, you can
 use `dd if=boot2docker.iso of=/dev/sdX`.  This will create the small boot
 partition, and install an MBR.
 
+## Configuring NFS (OSX)
+- To improve the speed of Boot2Docker drastically, you will want to set it up to use NFS instead of the Virtual box sharing option.
+- First set up your host machine's NFS server:
+  - Add this to /etc/exports on your mac
+  
+    ```
+    # BOOT2-DOCKER-BEGIN
+    /Users 192.168.59.103 -alldirs -mapall=501:20
+    # BOOT2-DOCKER-END
+    ```
+  - Run this command on your host machine
+  
+    ```sudo nfsd restart```
+- Then Start boot2docker and connect to the VM with ssh by doing the following:
+  
+  ```
+  boot2docker up
+  boot2docker ssh
+  ```
+  
+- Within boot2docker do the following
+  
+  - Open the the /var/lib/boot2docker/bootlocal.sh file for editing with the following command:
+  
+  ```sudo vi /var/lib/boot2docker/bootlocal.sh```
+
+  - Then add the following content to that script.
+
+    ```
+    #/bin/bash
+    sudo umount /Users
+    sudo /usr/local/etc/init.d/nfs-client start
+    sudo mount -t nfs -o rw --actimeo=2 192.168.59.3:/Users /Users
+    ```
+
+  - Then run the following
+  
+    ```
+    sudo chmod +x /var/lib/boot2docker/bootlocal.sh
+    ```
+
+- To test, restart boot2docker, ssh into boot2docker and run ```df``` to confirm. You should see something like the following:
+ 
+  ```
+  192.168.59.3:/Users     XG    XG    XG  X% /Users
+  ```
+
+- You're all done. :)
+
 #### Build your own Boot2Docker ISO
 
 Goto [How to build](doc/BUILD.md) for Documentation on how to build your own

--- a/README.md
+++ b/README.md
@@ -267,7 +267,11 @@ use `dd if=boot2docker.iso of=/dev/sdX`.  This will create the small boot
 partition, and install an MBR.
 
 ## Configuring NFS (OSX)
-- To improve the speed of Boot2Docker drastically, you will want to set it up to use NFS instead of the Virtual box sharing option.
+To improve the speed of Boot2Docker drastically, you will want to set it up to use NFS instead of the Virtual box sharing option.
+
+The easiest approach is to use this [automated script](scripts/enable_nfs.rb)
+
+For the manual breakdown, see the following:
 - First set up your host machine's NFS server:
   - Add this to /etc/exports on your mac
   

--- a/scripts/enable_nfs.rb
+++ b/scripts/enable_nfs.rb
@@ -50,7 +50,7 @@ print " #{vboxnet_ip}\n"
 # create record in local /etc/exports and restart nsfd
 machine_ip = `boot2docker ip`.chomp
 puts "Update /etc/exports ..."
-`echo '\n/Users #{machine_ip} -alldirs -maproot=root\n' | sudo tee -a /etc/exports`
+`echo '\n/Users #{machine_ip} -alldirs -mapall=501:20\n' | sudo tee -a /etc/exports`
 `awk '!a[$0]++' /etc/exports | sudo tee /etc/exports` # removes duplicate lines
 `sudo nfsd restart`; sleep 2
 puts `sudo nfsd checkexports`


### PR DESCRIPTION
I was able to get boot2docker to use NFS on OSX with the following steps. It's very possible I'm missing something important but if not, it would be great if you merged this!
