### PR TITLE
Fixed a broken path for the docker.sock

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -93,8 +93,8 @@ start() {
     ulimit -p $DOCKER_ULIMITS
 
     echo "------------------------" >> "$DOCKER_LOGFILE"
-    echo "/usr/local/bin/docker -d -D -g \"$DOCKER_DIR\" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"
-    /usr/local/bin/docker -d -D -g "$DOCKER_DIR" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> "$DOCKER_LOGFILE" 2>&1 &
+    echo "/usr/local/bin/docker -d -D -g \"$DOCKER_DIR\" -H unix:///var/run/docker.sock $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"
+    /usr/local/bin/docker -d -D -g "$DOCKER_DIR" -H unix:///var/run/docker.sock $DOCKER_HOST $EXTRA_ARGS >> "$DOCKER_LOGFILE" 2>&1 &
 }
 
 stop() {


### PR DESCRIPTION
I noticed after updating to the 1.6.0 docker iso that jwilder/nginx-proxy was failing. I've tracked this to a change in the unix socket path which I believe is due to a bug in the init script where the unix path is now set to unix://. This pull request just puts it back to unix:///var/run/docker.sock