### PR TITLE
automount: add partprobe operations to sync partition changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ ENV TCZ_DEPS        iptables \
                     git expat2 libiconv libidn libgpg-error libgcrypt libssh2 \
                     nfs-utils tcp_wrappers portmap rpcbind libtirpc \
                     curl ntpclient \
-                    procps glib2 libtirpc libffi fuse pcre
+                    procps glib2 libtirpc libffi fuse pcre \
+                    parted
 
 # Make the ROOTFS
 RUN mkdir -p $ROOTFS

--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -26,10 +26,16 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
 
             # Add a swap partition (so Docker doesn't complain about it missing)
             (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD
+            # Let kernel re-read partition table
+            partprobe
             (echo t; echo 2; echo 82; echo w) | fdisk $UNPARTITIONED_HD
+            # Let kernel re-read partition table
+            partprobe
             mkswap "${UNPARTITIONED_HD}2"
             # Add the data partition
             (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
+            # Let kernel re-read partition table
+            partprobe
             BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
             mkfs.ext4 -L $LABEL $BOOT2DOCKER_DATA
             swapon "${UNPARTITIONED_HD}2"


### PR DESCRIPTION
In some cases, kernel does not re-read partition table in time after fdisk changes.
The following mkswap/mkfs gets failure and complains that the partition does not exist.

This commit adds partprobe operations to fix this issue. Thanks!