### PR TITLE
Fix install-ca-files to use basename, not path

### DIFF
--- a/rootfs/rootfs/etc/rc.d/install-ca-certs
+++ b/rootfs/rootfs/etc/rc.d/install-ca-certs
@@ -6,7 +6,7 @@ CERTS_DIR=/etc/ssl/certs
 CAFILE=${CERTS_DIR}/ca-certificates.crt
 
 for cert_file in "${BOOT2DOCKER_CERTS_DIR}"/*.pem; do
-        cert=`basename $cert_file`
+	cert=`basename $cert_file`
 	echo "installing $cert"
 
 	SRC_CERT_FILE=${BOOT2DOCKER_CERTS_DIR}/${cert}

--- a/rootfs/rootfs/etc/rc.d/install-ca-certs
+++ b/rootfs/rootfs/etc/rc.d/install-ca-certs
@@ -5,7 +5,8 @@ BOOT2DOCKER_CERTS_DIR=/var/lib/boot2docker/certs
 CERTS_DIR=/etc/ssl/certs
 CAFILE=${CERTS_DIR}/ca-certificates.crt
 
-for cert in "${BOOT2DOCKER_CERTS_DIR}"/*.pem; do
+for cert_file in "${BOOT2DOCKER_CERTS_DIR}"/*.pem; do
+        cert=`basename $cert_file`
 	echo "installing $cert"
 
 	SRC_CERT_FILE=${BOOT2DOCKER_CERTS_DIR}/${cert}


### PR DESCRIPTION
I ran into this while trying out the instructions in the README. This change was required so that it will read the file correctly and handle the linking.

Fixes #873