### PR TITLE
Allow large core files by default

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -96,7 +96,7 @@ start() {
     ulimit -p $DOCKER_ULIMITS
     
     # Allow large core files by default
-    EXTRA_ARGS="$EXTRA_ARGS --default-ulimit core=-1""
+    EXTRA_ARGS="$EXTRA_ARGS --default-ulimit core=-1"
 
     echo "------------------------" >> "$DOCKER_LOGFILE"
     echo "/usr/local/bin/docker -d -D -g \"$DOCKER_DIR\" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -94,6 +94,9 @@ start() {
     # Increasing the number of open files and processes by docker
     ulimit -n $DOCKER_ULIMITS
     ulimit -p $DOCKER_ULIMITS
+    
+    # Allow large core files by default
+    EXTRA_ARGS="$EXTRA_ARGS --default-ulimit core=-1""
 
     echo "------------------------" >> "$DOCKER_LOGFILE"
     echo "/usr/local/bin/docker -d -D -g \"$DOCKER_DIR\" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"


### PR DESCRIPTION
Just started doing this on my docker hosts in the cloud.

Seemed like something worth having on boot2docker-based dev environments as well.