### PR TITLE
Docs: Make VM data persistence (or lack of) clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,16 @@ pass: tcuser
 
 #### Persist data
 
+Boot2docker uses [Tiny Core Linux](http://tinycorelinux.net), which runs from
+RAM and so does not persist filesystem changes by default.
+
 When you run `boot2docker init`, the `boot2docker` tool auto-creates a disk that
 will be automounted and used to persist your docker data in `/var/lib/docker`
 and `/var/lib/boot2docker`.  This virtual disk will be removed when you run
 `boot2docker delete`.  It will also persist the SSH keys of the machine.
+Changes outside of these directories will be lost after powering down or
+restarting the VM - to make permanent modifications see the
+[FAQ](doc/FAQ.md#local-customisation-with-persistent-partition).
 
 If you are not using the `boot2docker` management tool, you can create an `ext4`
 or `btrfs` formatted partition with the label `boot2docker-data` (`mkfs.ext4 -L

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -111,11 +111,14 @@ that doesn't exist, it will pick the first ``ext4`` partition listed by ``blkid`
 
 ## Local Customisation (with persistent partition)
 
-From Boot2Docker version 1.6.0, the `/var/lib/boot2docker/bootsync.sh` script is
-run before the Docker daemon is started.
+Changes outside of the `/var/lib/docker` and `/var/lib/boot2docker` directories
+will be lost after powering down or restarting the boot2docker VM. However, if
+you have a persistence partition (created automatically by `boot2docker init`),
+you can make customisations that are run at the end of boot initialisation by
+creating a script at ``/var/lib/boot2docker/bootlocal.sh``.
 
-If you have a persistence partition, you can make customisations that are run at
-the end of the boot initialisation in the ``/var/lib/boot2docker/bootlocal.sh`` file.
+From Boot2Docker version 1.6.0, you can also specify steps that are run before
+the Docker daemon is started, using `/var/lib/boot2docker/bootsync.sh`.
 
 You can also set variables that will be used during the boot initialisation (after
 the automount) by setting them in `/var/lib/boot2docker/profile`


### PR DESCRIPTION
Previously it was easy to not realise that data outside of `/var/lib/docker` and `/var/lib/boot2docker` would be lost after reboots of the VM. We now also link to the relevant FAQ section from the main README, so it's easier to work out how to make permanent modifications.

Fixes #912.