### PR TITLE
Embed docker-compose inside boot2docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,7 @@ RUN curl -L -o $ROOTFS/usr/local/bin/docker https://get.docker.io/builds/Linux/x
     { $ROOTFS/usr/local/bin/docker version || true; }
 
 # Get the docker-compose binary
-ENV COMPOSE_VERSION 1.2.0
+ENV COMPOSE_VERSION 1.3.1
 
 RUN curl -L -o $ROOTFS/usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-Linux-x86_64 && \
     chmod +x $ROOTFS/usr/local/bin/docker-compose && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -224,6 +224,13 @@ RUN curl -L -o $ROOTFS/usr/local/bin/docker https://get.docker.io/builds/Linux/x
     chmod +x $ROOTFS/usr/local/bin/docker && \
     { $ROOTFS/usr/local/bin/docker version || true; }
 
+# Get the docker-compose binary
+ENV COMPOSE_VERSION 1.2.0
+
+RUN curl -L -o $ROOTFS/usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-Linux-x86_64 && \
+    chmod +x $ROOTFS/usr/local/bin/docker-compose && \
+    $ROOTFS/usr/local/bin/docker-compose --version
+
 # Get the git versioning info
 COPY .git /git/.git
 RUN cd /git && \


### PR DESCRIPTION
Hello dear maintainers !

Since we have a lot of people dealing with boot2docker + virtual box portability issues (Windows essentially, but also vbox sharing folders and filesystem homogeneity between docker and compose client with the remote system), here is a little proposal to provide compose as a full part inside boot2docker.

Cons :
* Add a 5mb overhead :
```bash
docker@boot2docker:~$ docker-compose --version
docker-compose 1.2.0
docker@boot2docker:~$ du -sh /usr/local/bin/docker-compose 
5.0M	/usr/local/bin/docker-compose
```
* Docker-compose version is pretty tied to boot2docker releases (seems acceptable at first sight since you have a pretty good release monthly cycle)

Pros :
* Does not tie the end users to the use of compose in remote mode
* Let people use compose while you hard work on volumes, compose, boot2docker and all other hot stuff for this summer

Advices ?

For reference, here is a set of related issues/discussions on that topic (sendfile + vbox, windows support, docker volume path) :
* https://github.com/boot2docker/boot2docker/issues/603
* https://github.com/docker/compose/issues/599
* https://github.com/docker/compose/issues/1085

Thanks for your time !