### PR TITLE
Add XenServer guest tools to boot2docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y install  unzip \
                         bc \
                         git \
                         build-essential \
+                        golang \
                         cpio \
                         gcc libc6 libc6-dev \
                         kmod \
@@ -211,6 +212,19 @@ RUN mkdir -p /vmtoolsd/${LIBDNET} &&\
 # Horrible hack again
 RUN cd $ROOTFS && cd usr/local/lib && ln -s libdnet.1 libdumbnet.so.1 &&\
     cd $ROOTFS && ln -s lib lib64
+
+# Build XenServer Tools
+ENV XENTOOLS_REPO xe-guest-utilities
+ENV XENTOOLS_BRANCH boot2docker
+
+RUN cd / && \
+    git clone https://github.com/xenserver/$XENTOOLS_REPO && \
+    cd $XENTOOLS_REPO && \
+    git checkout $XENTOOLS_BRANCH && \
+    make && \
+    tar xvf build/dist/${XENTOOLS_REPO}_*.tgz -C $ROOTFS/ && \
+    cd / && \
+    rm -rf $XENTOOLS_REPO
 
 # Make sure that all the modules we might have added are recognized (especially VBox guest additions)
 RUN depmod -a -b $ROOTFS $KERNEL_VERSION-boot2docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,17 +214,15 @@ RUN cd $ROOTFS && cd usr/local/lib && ln -s libdnet.1 libdumbnet.so.1 &&\
     cd $ROOTFS && ln -s lib lib64
 
 # Build XenServer Tools
-ENV XENTOOLS_REPO xe-guest-utilities
-ENV XENTOOLS_BRANCH boot2docker
+ENV XEN_REPO https://github.com/xenserver/xe-guest-utilities
+ENV XEN_BRANCH boot2docker
+ENV XEN_COMMIT 4a9417fa61a5ca46676b7073fdb9181fe77ba56e
 
-RUN cd / && \
-    git clone https://github.com/xenserver/$XENTOOLS_REPO && \
-    cd $XENTOOLS_REPO && \
-    git checkout $XENTOOLS_BRANCH && \
-    make && \
-    tar xvf build/dist/${XENTOOLS_REPO}_*.tgz -C $ROOTFS/ && \
-    cd / && \
-    rm -rf $XENTOOLS_REPO
+RUN git clone -b "$XEN_BRANCH" "$XEN_REPO" /xentools \
+    && cd /xentools \
+    && git checkout -q "$XEN_COMMIT" \
+    && make \
+    && tar xvf build/dist/*.tgz -C $ROOTFS/
 
 # Make sure that all the modules we might have added are recognized (especially VBox guest additions)
 RUN depmod -a -b $ROOTFS $KERNEL_VERSION-boot2docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,8 @@ ENV TCZ_DEPS        iptables \
                     nfs-utils tcp_wrappers portmap rpcbind libtirpc \
                     curl ntpclient \
                     procps glib2 libtirpc libffi fuse pcre \
+                    udev-lib \
+                    liblvm2 \
                     parted
 
 # Make the ROOTFS

--- a/rootfs/rootfs/bootscript.sh
+++ b/rootfs/rootfs/bootscript.sh
@@ -88,3 +88,6 @@ fi
 
 # Launch vmware-tools
 /etc/rc.d/vmtoolsd
+
+# Launch xenserver-tools
+/etc/rc.d/xedaemon

--- a/rootfs/rootfs/etc/rc.d/xedaemon
+++ b/rootfs/rootfs/etc/rc.d/xedaemon
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -x /etc/init.d/xe-linux-distribution ]; then
+	/etc/init.d/xe-linux-distribution start
+fi

--- a/rootfs/rootfs/etc/rc.d/xedaemon
+++ b/rootfs/rootfs/etc/rc.d/xedaemon
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Tips: xentools will not start up if we're not on a Xen platform. 
+# 1. /etc/init.d/xe-linux-distribution will start /usr/sbin/xe-daemon.
+# 2. Then /usr/sbin/xe-daemon will quit if the VM is not run on a Xen platform.
 if [ -x /etc/init.d/xe-linux-distribution ]; then
 	/etc/init.d/xe-linux-distribution start
 fi


### PR DESCRIPTION
This PR adds golang-based XenServer guest tools to boot2docker.

The guest tools are mandatory to:
* Enable the hypervisor to find out the IP address of the VM (as for example required by Docker Machine)
* Migrate the running VM between multiple hosts in a pool

 Would appreciate feedback, questions, testing/review, error-reports - and a merge, once it's proven.

Signed-off-by: Phus Lu <phus.lu@citrix.com>