### PR TITLE
Add Parallels Tools support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,6 +225,18 @@ RUN mkdir -p /vmtoolsd/${LIBDNET} &&\
     make &&\
     make install && make DESTDIR=$ROOTFS install
 
+# Download and build Parallels Tools
+ENV PRL_TOOLS_URL = http://download.parallels.com/desktop/v11/11.0.0-rtm/ParallelsTools-11.0.0-30901-boot2docker.tar.gz
+
+RUN mkdir -p /prl_tools && curl -L $PRL_TOOLS_URL | tar -xzC /prl_tools --strip-components 1 &&\
+    cd /prl_tools &&\
+    cp -Rv tools/* $ROOTFS &&\
+    \
+    KERNEL_DIR=/linux-kernel/ KVER=$KERNEL_VERSION SRC=/linux-kernel/ PRL_FREEZE_SKIP=1 \
+    make -C kmods/ -f Makefile.kmods installme &&\
+    \
+    find kmods/ -name \*.ko -exec cp {} $ROOTFS/lib/modules/$KERNEL_VERSION-boot2docker/extra/ \;
+
 # Horrible hack again
 RUN cd $ROOTFS && cd usr/local/lib && ln -s libdnet.1 libdumbnet.so.1 &&\
     cd $ROOTFS && ln -s lib lib64

--- a/Dockerfile
+++ b/Dockerfile
@@ -226,9 +226,13 @@ RUN mkdir -p /vmtoolsd/${LIBDNET} &&\
     make install && make DESTDIR=$ROOTFS install
 
 # Download and build Parallels Tools
-ENV PRL_TOOLS_URL = http://download.parallels.com/desktop/v11/11.0.0-rtm/ParallelsTools-11.0.0-30901-boot2docker.tar.gz
+ENV PRL_MAJOR 11
+ENV PRL_VERSION 11.0.0
+ENV PRL_BUILD 30901
 
-RUN mkdir -p /prl_tools && curl -L $PRL_TOOLS_URL | tar -xzC /prl_tools --strip-components 1 &&\
+RUN mkdir -p /prl_tools && \
+    curl -L http://download.parallels.com/desktop/v${PRL_MAJOR}/${PRL_VERSION}-rtm/ParallelsTools-${PRL_VERSION}-${PRL_BUILD}-boot2docker.tar.gz \
+        | tar -xzC /prl_tools --strip-components 1 &&\
     cd /prl_tools &&\
     cp -Rv tools/* $ROOTFS &&\
     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -228,7 +228,7 @@ RUN mkdir -p /vmtoolsd/${LIBDNET} &&\
 # Download and build Parallels Tools
 ENV PRL_MAJOR 11
 ENV PRL_VERSION 11.0.0
-ENV PRL_BUILD 30901
+ENV PRL_BUILD 30916
 
 RUN mkdir -p /prl_tools && \
     curl -L http://download.parallels.com/desktop/v${PRL_MAJOR}/${PRL_VERSION}-rtm/ParallelsTools-${PRL_VERSION}-${PRL_BUILD}-boot2docker.tar.gz \

--- a/rootfs/rootfs/bootscript.sh
+++ b/rootfs/rootfs/bootscript.sh
@@ -96,3 +96,6 @@ fi
 
 # Launch xenserver-tools
 /etc/rc.d/xedaemon
+
+# Load Parallels Tools daemon
+/etc/rc.d/prltoolsd

--- a/rootfs/rootfs/etc/rc.d/prltoolsd
+++ b/rootfs/rootfs/etc/rc.d/prltoolsd
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/bin/sh /usr/local/etc/init.d/prltoolsd start
+/usr/local/etc/init.d/prltoolsd start

--- a/rootfs/rootfs/etc/rc.d/prltoolsd
+++ b/rootfs/rootfs/etc/rc.d/prltoolsd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/bin/sh /usr/local/etc/init.d/prltoolsd start


### PR DESCRIPTION
This PR adds a support of Parallels Tools, guest additions for Parallels Desktop for Mac.

In Dockerfile there is a link to an official build of Parallels Tools for Boot2Docker, supported by Parallels. We are going to keep it up-to-date and are ready to be responsible for Parallels Tools compatibility with the latest Boot2Docker version. 

Parallels Tools in bot2docker.iso are required to make Docker Machine compatible with Parallels Desktop for Mac: https://github.com/docker/machine/pull/939
Currently we have to use a custom build of boot2docker.iso: https://github.com/Parallels/boot2docker/releases/tag/v1.7.0-prl-tools

Features available in Boot2Docker with Parallels Tools:
- Parallels Shared Folders (`prl_fs` filesystem support);
- Graceful shutdown (by `prltoolsd`);
- Virtual network management (`prl_eth` kernel module and `prl_nettool`):
   * Setting network configuration (IP, DNS, DHCP etc.)
   * "touching" guest DHCP to renew lease on network adapter type change or on VM resume;
   * reporting guest network settings to the host.

Features will be implemented soon:
- TimeSync (by `prltoolsd`);
- Execute commands in guest with `prlctl exec` (by `prltoolsd`);

Note: Parallels Tools daemon is tolerant to other virtualization systems (and bare metal as well): it starts only if it is running on the Parallels Desktop virtualization environment. Otherwise, it exits silently.

*To maintainers:* If you would like to test an ISO with Docker Machine (from PR https://github.com/docker/machine/pull/939), we are ready to provide you an access to the pre-release version of Parallels Desktop 11, which is compatible with Boot2Docker and Docker Machine. Official release of Parallels Desktop 11 will be in Q3 2015.

Please, let me know if you need more information from Parallels.