### PR TITLE
trigger DHCP earlier, so that there's more chance that eth1 is up and…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -274,6 +274,9 @@ RUN cd /linux-kernel && \
 # Make sure init scripts are executable
 RUN find $ROOTFS/etc/rc.d/ $ROOTFS/usr/local/etc/init.d/ -exec chmod +x '{}' ';'
 
+# move dhcp.sh out of init.d as we're triggering it manually so its ready a bit faster
+RUN mv $ROOTFS/etc/init.d/dhcp.sh $ROOTFS/etc/rc.d/
+
 # Change MOTD
 RUN mv $ROOTFS/usr/local/etc/motd $ROOTFS/etc/motd
 

--- a/rootfs/rootfs/bootscript.sh
+++ b/rootfs/rootfs/bootscript.sh
@@ -9,6 +9,11 @@
 # Automount a hard drive
 /etc/rc.d/automount
 
+# Trigger the DHCP request sooner (the x64 bit userspace appears to be a second slower)
+echo "$(date) dhcp -------------------------------"
+/etc/rc.d/dhcp.sh
+echo "$(date) dhcp -------------------------------"
+
 # Mount cgroups hierarchy
 /etc/rc.d/cgroupfs-mount
 # see https://github.com/tianon/cgroupfs-mount


### PR DESCRIPTION
… ready for the cert generation

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

this may help with #824 

I'm going to try to make a setup where the `eth1` isn't ready in time, just to try to detect that, but this has helped in my testing.