### PR TITLE
Fix setting swap partition type during automount

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -28,7 +28,7 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
             (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD
             # Let kernel re-read partition table
             partprobe
-            (echo t; echo 2; echo 82; echo w) | fdisk $UNPARTITIONED_HD
+            (echo t; echo 82; echo w) | fdisk $UNPARTITIONED_HD
             # Let kernel re-read partition table
             partprobe
             mkswap "${UNPARTITIONED_HD}2"


### PR DESCRIPTION
The sequence `(echo t; echo 2; echo 82; echo w) | fdisk $UNPARTITIONED_HD` to set the partition type for the swap partition to 82/Linux swap in the `/etc/rc.d/automount` script currently fails to do so because it doesn't match the commands that actually have to be entered.

Apparently when there's only 1 partition fdisk already selects this partition:
```
# I ran this manually after the initial
# (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD

fdisk /dev/sda
...
Command (m for help): t
Selected partition 2
Hex code (type L to list codes):
```


No clue how long this hasn't been working correctly, but I couldn't find anything in the busybox release notes mentioning a change in fdisk behaviour related to this.

`fdisk -l` pre this fix
```
boot2docker ssh fdisk -l

Disk /dev/sda: 104.8 GB, 104857600000 bytes
255 heads, 63 sectors/track, 12748 cylinders
Units = cylinders of 16065 * 512 = 8225280 bytes

   Device Boot      Start         End      Blocks  Id System
/dev/sda1             124       12748   101410312+ 83 Linux
/dev/sda2               1         123      987966   2 Unknown

Partition table entries are not in disk order
```

`fdisk -l` after this fix
```
boot2docker ssh fdisk -l

Disk /dev/sda: 104.8 GB, 104857600000 bytes
255 heads, 63 sectors/track, 12748 cylinders
Units = cylinders of 16065 * 512 = 8225280 bytes

   Device Boot      Start         End      Blocks  Id System
/dev/sda1             124       12748   101410312+ 83 Linux
/dev/sda2               1         123      987966  82 Linux swap

Partition table entries are not in disk order
```