### PR TITLE
Add deprecation notice and rename to "boot2docker (Legacy)" to make room for the new "boot2docker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Boot2Docker
+# Deprecated
+
+This project ("boot2docker (Legacy)") is deprecated in favor of ["boot2docker"](https://github.com/docker/boot2docker) (reimagined and designed to be used in combination with [Docker Machine](https://docs.docker.com/machine/)).
+
+The source and documentation here remains for reference and transition purposes only.
+
+# Boot2Docker (Legacy)
 
 Boot2Docker is a lightweight Linux distribution made specifically to run
 [Docker](https://www.docker.com/) containers. It runs completely from RAM, is a


### PR DESCRIPTION
cc @ehazlett @nathanleclaire 

This isn't ready for merge just yet, but it should be ready for merge when it's time to finally pull the trigger (ie, the final release of Docker 1.8.0).

See also https://github.com/boot2docker/boot2docker-cli/pull/377 (related PR).

Fixes boot2docker/boot2docker#988