### PR TITLE
READY FOR REVIEW - work around OpenSSL issue which mistakes a cert as self-signed if CA org == cert org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN for dep in $TCZ_DEPS; do \
     done
 
 # get generate_cert
-RUN curl -L -o $ROOTFS/usr/local/bin/generate_cert https://github.com/SvenDowideit/generate_cert/releases/download/0.1/generate_cert-0.1-linux-386/ && \
+RUN curl -L -o $ROOTFS/usr/local/bin/generate_cert https://github.com/SvenDowideit/generate_cert/releases/download/0.2/generate_cert-0.2-linux-amd64 && \
     chmod +x $ROOTFS/usr/local/bin/generate_cert
 
 # Build VBox guest additions

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -20,6 +20,9 @@ test -f '/var/lib/boot2docker/profile' && . '/var/lib/boot2docker/profile'
 : ${SERVERKEY:="${CERTDIR}serverkey.pem"}
 : ${CERT:="${CERTDIR}cert.pem"}
 : ${KEY:="${CERTDIR}key.pem"}
+: ${ORG:=Boot2Docker}
+: ${SERVERORG:="${ORG}"}
+: ${CAORG:="${ORG}CA"} # Append 'CA'; see <http://rt.openssl.org/Ticket/History.html?use r=guest&pass=guest&id=3979>
 
 # Add /usr/local/sbin to the path.
 export PATH=${PATH}:/usr/local/sbin
@@ -41,21 +44,21 @@ start() {
         chmod 700 "$CERTDIR"
         if [ ! -f "$CACERT" ] || [ ! -f "$CAKEY" ]; then
             echo "Generating CA cert"
-            /usr/local/bin/generate_cert --cert="$CACERT" --key="$CAKEY"
+            /usr/local/bin/generate_cert --cert="$CACERT" --key="$CAKEY" --org="$CAORG"
             rm "$SERVERCERT" "$SERVERKEY" "$CERT" "$KEY" "$CERTDIR/hostnames"
         fi
 
         CERTSEXISTFOR=$(cat "$CERTDIR/hostnames" 2>/dev/null)
         if [ "$CERTHOSTNAMES" != "$CERTSEXISTFOR" ]; then
             echo "Generate server cert"
-            echo /usr/local/bin/generate_cert --host="$CERTHOSTNAMES" --ca="$CACERT" --ca-key="$CAKEY" --cert="$SERVERCERT" --key="$SERVERKEY"
-            /usr/local/bin/generate_cert --host="$CERTHOSTNAMES" --ca="$CACERT" --ca-key="$CAKEY" --cert="$SERVERCERT" --key="$SERVERKEY"
+            echo /usr/local/bin/generate_cert --host="$CERTHOSTNAMES" --ca="$CACERT" --ca-key="$CAKEY" --cert="$SERVERCERT" --key="$SERVERKEY" --org="$SERVERORG"
+            /usr/local/bin/generate_cert --host="$CERTHOSTNAMES" --ca="$CACERT" --ca-key="$CAKEY" --cert="$SERVERCERT" --key="$SERVERKEY" --org="$SERVERORG"
             echo "$CERTHOSTNAMES" > "$CERTDIR/hostnames"
         fi
 
         if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
             echo "Generating client cert"
-            /usr/local/bin/generate_cert --ca="$CACERT" --ca-key="$CAKEY" --cert="$CERT" --key="$KEY"
+            /usr/local/bin/generate_cert --ca="$CACERT" --ca-key="$CAKEY" --cert="$CERT" --key="$KEY" --org="$ORG"
         fi
 
         if [ "$DOCKER_TLS" == "auto" ]; then


### PR DESCRIPTION
Fix #808 and SvenDowideit/generate_cert#10. Update `generate_cert` to 0.2 (to gain access to the `--org` command line option). Use `--org` command line option to ensure org for automatically-generated CA cert differs from org for automatically-generated client/server certs. Work-around for OpenSSL bug (see <http://tinyurl.com/pqgnb2a>).

Merge needed for (i.e., blocks):

* docker/compose#890
* docker/docker-py#465
* possibly others

--

The Author grants to the owners of this repository, and the owners of the software it contains known as "boot2docker" (the Software), as well as their heirs and assigns (the Recipients), a perpetual and transferable license to all rights the Author may have to any material submitted in this pull request as if it were created by the Recipients themselves. By merging this pull request, the Recipients agree to indemnify and hold harmless its Author against any harm or liability from its inclusion in the Software or use.

ALL MATERIALS IN THIS PULL REQUEST ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL ITS AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.