### PR TITLE
ntpd now updates system time regardless of offset

### DIFF
--- a/rootfs/rootfs/etc/rc.d/ntpd
+++ b/rootfs/rootfs/etc/rc.d/ntpd
@@ -12,7 +12,7 @@ if [ -n "$NTP_SERVER" ]; then
 		fi
 	done
 	
-	ntpd -d -n -p $NTP_SERVER > /var/lib/boot2docker/log/ntpd.log 2>&1 &
+	ntpd -d -g -n -p $NTP_SERVER > /var/lib/boot2docker/log/ntpd.log 2>&1 &
 else
 	echo 'NTP_SERVER not set; skipping starting ntpd' > /var/lib/boot2docker/log/ntpd.log
 fi


### PR DESCRIPTION
Fixes #840

From the `ntpd` man page: 
-g: Normally, ntpd exits with a message to the system log if the offset exceeds the panic threshold, which is 1000 s by default. This option allows the time to be set to any value without restriction; however, this can happen only once. If the threshold is exceeded after that, ntpd will exit with a message to the system log. This option can be used with the -q and -x options. See the tinker command for other options.