### PR TITLE
Revert "ntpd now updates system time regardless of offset"

### DIFF
--- a/rootfs/rootfs/etc/rc.d/ntpd
+++ b/rootfs/rootfs/etc/rc.d/ntpd
@@ -12,7 +12,7 @@ if [ -n "$NTP_SERVER" ]; then
 		fi
 	done
 	
-	ntpd -d -g -n -p $NTP_SERVER > /var/lib/boot2docker/log/ntpd.log 2>&1 &
+	ntpd -d -n -p $NTP_SERVER > /var/lib/boot2docker/log/ntpd.log 2>&1 &
 else
 	echo 'NTP_SERVER not set; skipping starting ntpd' > /var/lib/boot2docker/log/ntpd.log
 fi


### PR DESCRIPTION
Reverts boot2docker/boot2docker#1035

Oops: (https://github.com/boot2docker/boot2docker/pull/1035#issuecomment-131891255)
```console
docker@boot2docker:~$ sudo ntpd --help
BusyBox v1.23.1 (2015-02-22 15:53:49 UTC) multi-call binary.

Usage: ntpd [-dnqNw] [-S PROG] [-p PEER]...

NTP client/server

	-d	Verbose
	-n	Do not daemonize
	-q	Quit after clock is set
	-N	Run at high priority
	-w	Do not set time (only query peers), implies -n
	-S PROG	Run PROG after stepping time, stratum change, and every 11 mins
	-p PEER	Obtain time from PEER (may be repeated)
		If -p is not given, read /etc/ntp.conf

```