### PR TITLE
Use iocharset=utf8 for automunt-shares

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount-shares
+++ b/rootfs/rootfs/etc/rc.d/automount-shares
@@ -6,7 +6,7 @@ set -e
 # VirtualBox Guest Additions
 # - this will bail quickly and gracefully if we're not in VBox
 if modprobe vboxguest &> /dev/null && modprobe vboxsf &> /dev/null; then
-	mountOptions='defaults'
+	mountOptions='defaults,iocharset=utf8'
 	if grep -q '^docker:' /etc/passwd; then
 		mountOptions="${mountOptions},uid=$(id -u docker),gid=$(id -g docker)"
 	fi


### PR DESCRIPTION
According to the document, it said that iocharset is default to utf8, however, actual behavior is not.
Force using utf8 to address the issue that non-ascii characters files disapper from the shared folders.

This is basically same as boot2docker/boot2docker#697 which is not updated since May, but doesn't change `mount -t vbox` to `mount.vbox` also keeps `defaults` option.

This will solve the issue similar to docker/machine#1763.

Closes boot2docker/boot2docker#697