### PR TITLE
automated_script.sh is written by ash for enable kernel option script

### DIFF
--- a/rootfs/rootfs/bootscript.sh
+++ b/rootfs/rootfs/bootscript.sh
@@ -83,8 +83,7 @@ if [ -e /var/lib/boot2docker/bootlocal.sh ]; then
 fi
 
 # Execute automated_script
-# disabled - this script was written assuming bash, which we no longer have.
-#/etc/rc.d/automated_script.sh
+/bin/sh /etc/rc.d/automated_script.sh
 
 # Run Hyper-V KVP Daemon
 if modprobe hv_utils &> /dev/null; then

--- a/rootfs/rootfs/etc/rc.d/automated_script.sh
+++ b/rootfs/rootfs/etc/rc.d/automated_script.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 script_cmdline ()
 {
     local param
-    for param in $(< /proc/cmdline); do
+    for param in $(cat /proc/cmdline); do
         case "${param}" in
             script=*) echo "${param##*=}" ; return 0 ;;
         esac
@@ -15,7 +15,7 @@ automated_script ()
     local script rt
     script="$(script_cmdline)"
     if [[ -n "${script}" && ! -x /tmp/startup_script ]]; then
-        if [[ "${script}" =~ ^http:// || "${script}" =~ ^ftp:// ]]; then
+        if [[ "${script%%//*}" == "http:" || "${script%%//*}" == "ftp:" ]]; then
             curl -fsL "${script}" -o /tmp/startup_script
             rt=$?
         else
@@ -29,6 +29,4 @@ automated_script ()
     fi
 }
 
-if [[ $(tty) == "/dev/tty1" ]]; then
-    automated_script
-fi
+automated_script


### PR DESCRIPTION
Rewrite automated_script.sh by ash.
Karnel option "script" is useful to install on bare metal server.
`if [[ $(tty) == "/dev/tty1" ]]; then`
looks unnecessary for boot2docker.
As in arch linux .automated_script.sh is called by .zlogin, that guard is necessary for arch linux.
https://projects.archlinux.org/archiso.git/commit/?id=d552ad32ab7001766ec2cdf6d2c555e91267a7cb
