### PR TITLE
docker daemon status not work correctly

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -116,7 +116,7 @@ restart() {
 }
 
 check() {
-    [ -f /var/run/docker.pid ] && ps -o pid | grep "^\s*$(cat /var/run/docker.pid)$" > /dev/null 2>&1
+    [ -f /var/run/docker.pid ] && ps -A -o pid | grep `cat /var/run/docker.pid` > /dev/null 2>&1
 }
 
 status() {

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -116,7 +116,7 @@ restart() {
 }
 
 check() {
-    [ -f /var/run/docker.pid ] && ps -A -o pid | grep `cat /var/run/docker.pid` > /dev/null 2>&1
+    [ -f /var/run/docker.pid ] && ps -A -o pid | grep "^\s*$(cat /var/run/docker.pid)$" > /dev/null 2>&1
 }
 
 status() {


### PR DESCRIPTION
When want you to know status of docker daemon with :

root@default:/etc/init.d# ./docker status
Docker daemon is not running
root@default:/etc/init.d#

But with ps, docker is running 

root@default:/etc/init.d# ps -ef | grep `cat /var/run/docker.pid`
root      1218     1  0 07:54 ?        00:00:00 /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// -H tcp://0.0.0.0:2376 --label provider=virtualbox --tlsverify --tlscacert=/var/lib/boot2docker/ca.pem --tlscert=/var/lib/boot2docker/server.pem --tlskey=/var/lib/boot2docker/server-key.pem -s aufs
root      1601  1324  0 08:12 pts/0    00:00:00 grep 1218

In function check()

ps -o pid | grep "^\s*$(cat /var/run/docker.pid)$" return false status of docker daemon

root@default:/etc/init.d# ps -o pid
  PID
 1324
 1692

My solution
root@default:/etc/init.d# ps -A -o pid | grep `cat /var/run/docker.pid`
 1218
root@default:/etc/init.d#

