### PR TITLE
Use openssl.tcz instead of openssl-1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ ENV TCL_REPO_BASE   http://tinycorelinux.net/6.x/x86_64
 # Note that the ncurses is here explicitly so that top continues to work
 ENV TCZ_DEPS        iptables \
                     iproute2 \
-                    openssh openssl-1.0.0 \
+                    openssh openssl \
                     tar \
                     gcc_libs \
                     ncurses \


### PR DESCRIPTION
This update should fix the issues seen in #1055. The `openssl.tcz` extension contains OpenSSL 1.0.2d while the `openssl-1.0.0.tcz` extension contains OpenSSL 1.0.0k.