### PR TITLE
Ensure daemon listens on /var/run/docker.sock

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -99,8 +99,8 @@ start() {
     ulimit -p $DOCKER_ULIMITS
 
     echo "------------------------" >> "$DOCKER_LOGFILE"
-    echo "/usr/local/bin/docker daemon -D -g \"$DOCKER_DIR\" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"
-    /usr/local/bin/docker daemon -D -g "$DOCKER_DIR" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> "$DOCKER_LOGFILE" 2>&1 &
+    echo "/usr/local/bin/docker daemon -D -g \"$DOCKER_DIR\" -H unix:///var/run/docker.sock $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"
+    /usr/local/bin/docker daemon -D -g "$DOCKER_DIR" -H unix:///var/run/docker.sock $DOCKER_HOST $EXTRA_ARGS >> "$DOCKER_LOGFILE" 2>&1 &
 }
 
 stop() {


### PR DESCRIPTION
This fixes a breaking change from #1034 that prevents running `docker` commands locally in the boot2docker shell or using any container that mounts the default Docker Unix domain socket for its functionality (e.g. `jwilder/nginx-proxy`).