### PR TITLE
Add information about jrotter/boot2docker-automounter in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,11 @@ $ mount -t vboxsf -o uid=1000,gid=50 your-other-share-name /some/mount/location
 It is also important to note that in the future, the plan is to have any share
 which is created in VirtualBox with the "automount" flag turned on be mounted
 during boot at the directory of the share name (ie, a share named `home/jsmith`
-would be automounted at `/home/jsmith`).
+would be automounted at `/home/jsmith`). Currently this can be achieved by running
+`jrotter/boot2docker-automounter` container:
+```console
+$ docker run -d --restart=always --privileged -v /proc:/hproc --name automounter jrotter/boot2docker-automounter
+```
 
 In case it isn't already clear, the Linux host support here is currently hazy.
 You can share your `/home` or `/home/jsmith` directory as `Users` or one of the


### PR DESCRIPTION
Hi,
I'd just like to let you know, that I've created a container that automatically mounts the 'automount' marked shares from the VirtualBox on the boot2docker. Please see the: https://github.com/janrotter/boot2docker-automounter for more details.

If you find it to be useful, please add a note to your readme, to let others know.

Best regards,
Jan
