### PR TITLE
Hotfix: Parallels kernel modules are unavailable in v1.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,7 @@ RUN mkdir -p /prl_tools && \
     KERNEL_DIR=/linux-kernel/ KVER=$KERNEL_VERSION SRC=/linux-kernel/ PRL_FREEZE_SKIP=1 \
     make -C kmods/ -f Makefile.kmods installme &&\
     \
-    find kmods/ -name \*.ko -exec cp {} $ROOTFS/lib/modules/$KERNEL_VERSION-boot2docker/extra/ \;
+    find kmods/ -name \*.ko -exec cp {} $ROOTFS/lib/modules/$KERNEL_VERSION-boot2docker/ \;
 
 # Build XenServer Tools
 ENV XEN_REPO https://github.com/xenserver/xe-guest-utilities


### PR DESCRIPTION
Due to #1054, the `extra` subdirectory is no longer created. I was too naive while putting Parallels kernel modules to this dir :-(

So, in v1.8.3 there are no kernel modules from Parallels Tools, which causes a critical issue with shared folder mounting: https://github.com/Parallels/docker-machine/issues/7

In this PR I've changed the path for storing kernel modules from Parallels: let them be in the top level dir, adjacent to vbox modules.

@tianon Please, review this PR. We looking forward to get it released ASAP :pray: 
