### PR TITLE
fsck partition before mount

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -82,6 +82,10 @@ echo $BOOT2DOCKER_DATA
 
 if [ -n "$BOOT2DOCKER_DATA" ]; then
     PARTNAME=`echo "$BOOT2DOCKER_DATA" | sed 's/.*\///'`
+    
+    echo "fsck $BOOT2DOCKER_DATA"
+    fsck -y BOOT2DOCKER_DATA
+    
     echo "mount p:$PARTNAME ..."
     mkdir -p /mnt/$PARTNAME
     if ! mount $BOOT2DOCKER_DATA /mnt/$PARTNAME 2>/dev/null; then
@@ -91,7 +95,7 @@ if [ -n "$BOOT2DOCKER_DATA" ]; then
         umount -f /mnt/$PARTNAME || true
         mount $BOOT2DOCKER_DATA /mnt/$PARTNAME
     fi
-
+    
     # Just in case, the links will fail if not
     umount -f /var/lib/docker || true
     rm -rf /var/lib/docker /var/lib/boot2docker


### PR DESCRIPTION
we found filesystem  error on some boot2docker vms (on esxi)

when boot2docker is up, cannot umount the boot2docker-data device

if would be great for check and fix the issue on boot:)
