### PR TITLE
Remove automatic certificate generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,10 +138,6 @@ RUN for dep in $TCZ_DEPS; do \
         rm -f /tmp/$dep.tcz ;\
     done
 
-# get generate_cert
-RUN curl -fL -o $ROOTFS/usr/local/bin/generate_cert https://github.com/SvenDowideit/generate_cert/releases/download/0.2/generate_cert-0.2-linux-amd64 && \
-    chmod +x $ROOTFS/usr/local/bin/generate_cert
-
 # Build VBox guest additions
 ENV VBOX_VERSION 5.0.8
 RUN mkdir -p /vboxguest && \

--- a/README.md
+++ b/README.md
@@ -135,21 +135,6 @@ boot2docker ssh -t sudo vi /var/lib/boot2docker/profile
 boot2docker restart
 ```
 
-#### TLS support
-
-By default, `boot2docker` runs `docker` with TLS enabled. It auto-generates
-certificates and stores them in `/home/docker/.docker` inside the VM. The
-`boot2docker up` command will copy them to `~/.boot2docker/certs` on the
-host machine once the VM has started, and output the correct values for
-the `DOCKER_CERT_PATH` and `DOCKER_TLS_VERIFY` environment variables.
-
-`eval "$(boot2docker shellinit)"` will also set them correctly.
-
-We strongly recommend against running Boot2Docker with an unencrypted Docker
-socket for security reasons, but if you have tools that cannot be easily
-switched, you can disable it by adding `DOCKER_TLS=no` to your
-`/var/lib/boot2docker/profile` file.
-
 #### Folder sharing
 
 Boot2Docker is essentially a remote Docker engine with a read only filesystem

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -5,78 +5,150 @@
 #import settings from profile (e.g. HTTP_PROXY, HTTPS_PROXY)
 test -f '/var/lib/boot2docker/profile' && . '/var/lib/boot2docker/profile'
 
-: ${DOCKER_HOST:='-H tcp://0.0.0.0:2375'}
-: ${DOCKER_TLS:=auto}
 : ${DOCKER_STORAGE:=auto}
 : ${DOCKER_DIR:=/var/lib/docker}
 : ${DOCKER_ULIMITS:=1048576}
 : ${DOCKER_LOGFILE:=/var/lib/boot2docker/docker.log}
 
-: ${CERTDIR:=/var/lib/boot2docker/tls/}
+# before setting defaults, let's check what was in /var/lib/boot2docker/profile
+if [ -n "$DOCKER_TLS" -a -z "$DOCKER_REMOTE" ]; then
+	# if /var/lib/boot2docker/profile sets DOCKER_TLS but not DOCKER_REMOTE, assume
+	DOCKER_REMOTE=yes
+fi
+
+: ${DOCKER_REMOTE:=no} # 'yes' or anything else for 'no'
+: ${DOCKER_TLS:=yes} # 'no' or anything else for 'yes' (obviously has no effect if DOCKER_REMOTE is not explicitly "yes")
 : ${CERT_INTERFACES:='eth0 eth1'}
-: ${CACERT:="${CERTDIR}ca.pem"}
-: ${CAKEY:="${CERTDIR}cakey.pem"}
-: ${SERVERCERT:="${CERTDIR}server.pem"}
-: ${SERVERKEY:="${CERTDIR}serverkey.pem"}
-: ${CERT:="${CERTDIR}cert.pem"}
-: ${KEY:="${CERTDIR}key.pem"}
+: ${CERTDIR:=/var/lib/boot2docker/tls}
+: ${CACERT:="${CERTDIR}/ca.pem"}
+: ${CAKEY:="${CERTDIR}/cakey.pem"}
+: ${CASRL:="${CERTDIR}/ca.srl"}
+: ${SERVERCERT:="${CERTDIR}/server.pem"}
+: ${SERVERKEY:="${CERTDIR}/serverkey.pem"}
+: ${SERVERCSR:="${CERTDIR}/server.csr"}
+: ${CERT:="${CERTDIR}/client.pem"}
+: ${KEY:="${CERTDIR}/clientkey.pem"}
+: ${CSR:="${CERTDIR}/client.csr"}
 : ${ORG:=Boot2Docker}
 : ${SERVERORG:="${ORG}"}
-: ${CAORG:="${ORG}CA"} # Append 'CA'; see <http://rt.openssl.org/Ticket/History.html?use r=guest&pass=guest&id=3979>
+: ${CAORG:="${ORG} CA"} # Append 'CA'; see <http://rt.openssl.org/Ticket/History.html?id=3979>
+
+USERHOME="$(awk -F: '$1 == "docker" { print $6; exit }' /etc/passwd)"
+: ${USERHOME:=/home/docker}
+USERUIDGID="$(awk -F: '$1 == "docker" { print $3 ":" $4; exit }' /etc/passwd)"
+: ${USERUIDGID:=docker}
+USERCFG="$USERHOME/.docker"
 
 # Add /usr/local/sbin to the path.
 export PATH=${PATH}:/usr/local/sbin
 
 start() {
-    # Not enabling Docker daemon TLS by default.
-    if [ "$DOCKER_TLS" != "no" ]; then
-        CERTHOSTNAMES="$(hostname -s),$(hostname -i)"
-        for interface in ${CERT_INTERFACES}; do
-          IPS=$(ip addr show ${interface} |sed -nEe 's/^[ \t]*inet[ \t]*([0-9.]+)\/.*$/\1/p')
-          for ip in $IPS; do
-            CERTHOSTNAMES="$CERTHOSTNAMES,$ip"
-          done
-        done
-        echo "Need TLS certs for $CERTHOSTNAMES"
-        echo "-------------------"
-
-        mkdir -p "$CERTDIR"
-        chmod 700 "$CERTDIR"
-        if [ ! -f "$CACERT" ] || [ ! -f "$CAKEY" ]; then
-            echo "Generating CA cert"
-            /usr/local/bin/generate_cert --cert="$CACERT" --key="$CAKEY" --org="$CAORG"
-            rm "$SERVERCERT" "$SERVERKEY" "$CERT" "$KEY" "$CERTDIR/hostnames"
-        fi
-
-        CERTSEXISTFOR=$(cat "$CERTDIR/hostnames" 2>/dev/null)
-        if [ "$CERTHOSTNAMES" != "$CERTSEXISTFOR" ]; then
-            echo "Generate server cert"
-            echo /usr/local/bin/generate_cert --host="$CERTHOSTNAMES" --ca="$CACERT" --ca-key="$CAKEY" --cert="$SERVERCERT" --key="$SERVERKEY" --org="$SERVERORG"
-            /usr/local/bin/generate_cert --host="$CERTHOSTNAMES" --ca="$CACERT" --ca-key="$CAKEY" --cert="$SERVERCERT" --key="$SERVERKEY" --org="$SERVERORG"
-            echo "$CERTHOSTNAMES" > "$CERTDIR/hostnames"
-        fi
-
-        if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
-            echo "Generating client cert"
-            /usr/local/bin/generate_cert --ca="$CACERT" --ca-key="$CAKEY" --cert="$CERT" --key="$KEY" --org="$ORG"
-        fi
-
-        if [ "$DOCKER_TLS" == "auto" ]; then
-            DOCKER_HOST='-H tcp://0.0.0.0:2376'
-            EXTRA_ARGS="$EXTRA_ARGS --tlsverify --tlscacert=$CACERT --tlscert=$SERVERCERT --tlskey=$SERVERKEY"
-        elif [ "$DOCKER_TLS" != "no" ]; then
-            EXTRA_ARGS="$EXTRA_ARGS $DOCKER_TLS --tlscacert=$CACERT --tlscert=$SERVERCERT --tlskey=$SERVERKEY"
-        fi
-
-        # now make the client certificates available to the docker user
-        USERCFG="/home/docker/.docker"
-        mkdir -p "$USERCFG"
-        chmod 700 "$USERCFG"
-        cp "$CACERT" "$USERCFG"
-        cp "$CERT" "$USERCFG"
-        cp "$KEY" "$USERCFG"
-        chown -R docker:staff "$USERCFG"
-    fi
+	if [ 'yes' = "$DOCKER_REMOTE" ]; then
+		if [ 'no' = "$DOCKER_TLS" ]; then
+			EXTRA_ARGS="$EXTRA_ARGS -H tcp://0.0.0.0:2375"
+		else
+			# see https://docs.docker.com/articles/https/
+			# and https://gist.github.com/Stono/7e6fed13cfd79598eb15
+			EXTRA_ARGS="$EXTRA_ARGS -H tcp://0.0.0.0:2376 --tlsverify"
+			mkdir -p "$CERTDIR"
+			chmod 700 "$CERTDIR"
+			if [ ! -f "$CAKEY" ]; then
+				echo "Generating $CAKEY"
+				openssl genrsa \
+					-out "$CAKEY" \
+					4096
+			fi
+			if [ ! -f "$CACERT" ]; then
+				echo "Generating $CACERT"
+				openssl req \
+					-new \
+					-key "$CAKEY" \
+					-x509 \
+					-days 365 \
+					-nodes \
+					-subj "/O=$CAORG" \
+					-out "$CACERT"
+			fi
+			EXTRA_ARGS="$EXTRA_ARGS --tlscacert=$CACERT"
+			if [ ! -f "$CASRL" ]; then
+				echo '01' > "$CASRL"
+			fi
+			if [ ! -f "$SERVERKEY" ]; then
+				echo "Generating $SERVERKEY"
+				openssl genrsa \
+					-out "$SERVERKEY" \
+					4096
+			fi
+			EXTRA_ARGS="$EXTRA_ARGS --tlskey=$SERVERKEY"
+			if [ ! -f "$SERVERCERT" ]; then
+				echo "Generating $SERVERCERT"
+				commonName="$(hostname -s)"
+				altName="IP:$(hostname -i)"
+				altName="$altName,IP:127.0.0.1"
+				altName="$altName,DNS:localhost,DNS:localhost.local"
+				altName="$altName,IP:::1"
+				altName="$altName,DNS:ip6-localhost,DNS:ip6-loopback"
+				for interface in $CERT_INTERFACES; do
+					ips=$(ip addr show "$interface" | awk -F '[/[:space:]]+' '$2 == "inet" { print $3 }')
+					for ip in $ips; do
+						altName="$altName,IP:$ip"
+					done
+				done
+				openssl req \
+					-new \
+					-key "$SERVERKEY" \
+					-subj "/O=$SERVERORG/CN=$commonName" \
+					-out "$SERVERCSR"
+				extfile="$CERTDIR/extfile.cnf"
+				echo "subjectAltName = $altName" > "$extfile"
+				openssl x509 \
+					-req \
+					-days 365 \
+					-in "$SERVERCSR" \
+					-CA "$CACERT" \
+					-CAkey "$CAKEY" \
+					-out "$SERVERCERT" \
+					-extfile "$extfile"
+				rm "$extfile"
+			fi
+			EXTRA_ARGS="$EXTRA_ARGS --tlscert=$SERVERCERT"
+			if [ ! -f "$KEY" ]; then
+				echo "Generating $KEY"
+				openssl genrsa \
+					-out "$KEY" \
+					4096
+			fi
+			if [ ! -f "$CERT" ]; then
+				echo "Generating $CERT"
+				openssl req \
+					-new \
+					-key "$KEY" \
+					-subj "/O=$ORG" \
+					-out "$CSR"
+				extfile="$CERTDIR/extfile.cnf"
+				echo 'extendedKeyUsage = clientAuth' > "$extfile"
+				openssl x509 \
+					-req \
+					-days 365 \
+					-in "$CSR" \
+					-CA "$CACERT" \
+					-CAkey "$CAKEY" \
+					-out "$CERT" \
+					-extfile "$extfile"
+				rm "$extfile"
+			fi
+			mkdir -p "$USERCFG"
+			chmod 700 "$USERCFG"
+			chown "$USERUIDGID" "$USERCFG"
+			cp "$CACERT" "$USERCFG/ca.pem"
+			chown "$USERUIDGID" "$USERCFG/ca.pem"
+			cp "$CERT" "$USERCFG/cert.pem"
+			chown "$USERUIDGID" "$USERCFG/cert.pem"
+			cp "$KEY" "$USERCFG/key.pem"
+			chmod 700 "$USERCFG/key.pem"
+			chown "$USERUIDGID" "$USERCFG/key.pem"
+		fi
+	fi
 
     mkdir -p "$DOCKER_DIR"
 
@@ -99,8 +171,8 @@ start() {
     ulimit -p $DOCKER_ULIMITS
 
     echo "------------------------" >> "$DOCKER_LOGFILE"
-    echo "/usr/local/bin/docker daemon -D -g \"$DOCKER_DIR\" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"
-    /usr/local/bin/docker daemon -D -g "$DOCKER_DIR" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> "$DOCKER_LOGFILE" 2>&1 &
+    echo "/usr/local/bin/docker daemon -D -g \"$DOCKER_DIR\" -H unix:// $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"
+    /usr/local/bin/docker daemon -D -g "$DOCKER_DIR" -H unix:// $EXTRA_ARGS >> "$DOCKER_LOGFILE" 2>&1 &
 }
 
 stop() {


### PR DESCRIPTION
Since Docker Machine is performing this generation regardless, it doesn't make sense for boot2docker's scripts to waste time doing the same.

See https://github.com/docker/machine/issues/2018 for further discussion.

cc @nathanleclaire
