### PR TITLE
Add rsync and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ ENV TCZ_DEPS        iptables \
                     xz liblzma \
                     git expat2 libiconv libidn libgpg-error libgcrypt libssh2 \
                     nfs-utils tcp_wrappers portmap rpcbind libtirpc \
+                    rsync attr acl \
                     curl ntpclient \
                     procps glib2 libtirpc libffi fuse pcre \
                     udev-lib \


### PR DESCRIPTION
Hi there!

Using Virtualbox shared folders and NFS we were never able to approach the performance we needed for our development environments, so we turned to rsync. (https://github.com/roverdotcom/docker-rsync/tree/rover)

Specifically:

- The vboxsf solution showed an 80%-100% slowdown relative to bare metal for application server reload & Python module loading when running our test suite.
- The NFS solution showed more like ~50% slowdowns for many tasks and our Django application often wouldn't detect filesystem changes either fast enough or at all.

By comparison, various metrics show either no slowdown or a ~10% slowdown relative to bare metal for the rsync solution.

Currently, the rsync solution requires running `tce-load -wi rsync attr acl` on each restart which creates a dependency on networking availability.

We can definitely roll our own `boot2docker` image if needed, but we were hoping we could get those packages added to the base image given how large the performance improvement is for the core OSX use-case and that it has no impact on the size of the resulting ISO.

Here's a comparison of the two ISOs - I'm actually surprised it has no impact on the size, though that's probably down to me not understanding how that step works -

```bash
philip$ md5 boot2docker*.iso
MD5 (boot2docker-master.iso) = bc0392e3eacef26839b680d336c27adb
MD5 (boot2docker-rsync.iso) = b1452d7402ed384f9a593bb44ddf0ba8
philip$ du boot2docker*.iso
61440	boot2docker-master.iso
61440	boot2docker-rsync.iso
```

We're also working on making `docker-rsync` a bit more usable, especially when moving around large files.

Let me know if this is something you'd consider getting into future releases!