### PR TITLE
Automatically mount /Users on boot if it's present

### DIFF
--- a/rootfs/rootfs/etc/rc.d/vmtoolsd
+++ b/rootfs/rootfs/etc/rc.d/vmtoolsd
@@ -10,6 +10,11 @@ if [ "$SYSTYPE" -gt 0 ]; then
 		# if shared folders are disabled on the host, vmtoolsd will take care of the mount
 		# if they are enabled while the machine is running.
 		/usr/local/bin/vmhgfs-fuse -o allow_other .host:/ /mnt/hgfs
+		if [ -x /mnt/hgfs/Users ]; then
+			mkdir -p /Users
+			/usr/local/bin/vmhgfs-fuse -o allow_other .host:/Users /Users
+
+		fi
 	fi
 
 	ln -s /usr/local/bin/lsb_release /usr/bin/lsb_release


### PR DESCRIPTION
Now this mount is done from docker-machine on create and start, but don't put to startup scripts.

So on plain machine reboot this directory is not mounted.
