### PR TITLE
Fix /etc/init.d/docker restart

### DIFF
--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -114,10 +114,15 @@ stop() {
 
 restart() {
     if check; then
-        stop && sleep 1 && start
-    else
-        start
+        stop
+        i=30
+        while check ; do
+            sleep 1
+            i=$(expr $i - 1)
+            [ "$i" -gt 0 ] || { echo "Failed to stop Docker dameon" ; exit 1 ; }
+        done
     fi
+    start
 }
 
 check() {


### PR DESCRIPTION
Docker daemon takes forever and a half to exit (about 10s on a
fresh boot2docker 1.10 VM). Attempting to restart before it is
stopped just fails miserably: start aborts and stop eventually
completes.

Arguably start and stop should only return once the daemon is
actually started/stopped but that might impose undue delay on
callers that only care about an eventual state change and are
unmoved by the prospect of race conditions.