### PR TITLE
Use a higher ratio of inodes to address inode exhaustion in overlayfs

### DIFF
--- a/rootfs/rootfs/etc/rc.d/automount
+++ b/rootfs/rootfs/etc/rc.d/automount
@@ -49,7 +49,7 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
                 sleep 0.5
             done
             BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
-            mkfs.ext4 -L $LABEL $BOOT2DOCKER_DATA
+            mkfs.ext4 -i 8192 -L $LABEL $BOOT2DOCKER_DATA
             swapon "${UNPARTITIONED_HD}2"
         fi
 
@@ -74,7 +74,7 @@ if [ ! -n "$BOOT2DOCKER_DATA" ]; then
                     # Add the data partition
                     (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
                     BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
-                    mkfs.ext4 -L $LABEL $BOOT2DOCKER_DATA
+                    mkfs.ext4 -i 8192 -L $LABEL $BOOT2DOCKER_DATA
                     swapon "${UNPARTITIONED_HD}2"
                 else
                     echo "Disk unpartitioned but something is there... not doing anything"


### PR DESCRIPTION
We've been encountering regular inode exhaustion with boot2docker/docker-machine. It seems like this is a problem that is likely to be affecting more and more people with the gradual convergence on overlayfs. 

I'd hoped to be able to pass a parameter somehow to the `automount` script, I guess via a kernel boot parameter? That would address #992. I couldn't figure out a way to do that, any suggestions? 
