### PR TITLE
WIP: Update to AUFS 4.1.13+-20160219

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN curl --retry 10 https://www.kernel.org/pub/linux/kernel/v${KERNEL_VERSION%%.
 # http://aufs.sourceforge.net/
 ENV AUFS_REPO       https://github.com/sfjro/aufs4-standalone
 ENV AUFS_BRANCH     aufs4.1.13+
-ENV AUFS_COMMIT     1aa8a143457147473edc97035a7f4b89f9d234ae
+ENV AUFS_COMMIT     326c11489fa0649462f6424ef941f4ea449d53c3
 # we use AUFS_COMMIT to get stronger repeatability guarantees
 
 # Download AUFS and apply patches and files, then remove it


### PR DESCRIPTION
This needs more testing and debugging to figure out why we're getting errors like the following when trying to launch containers:

```console
$ docker run -it --rm alpine:3.3 sh
docker: Error response from daemon: open /var/lib/docker/aufs/mnt/fd093f42c4790454282b3ee7bacf57ccee00527a9d30c4b430d830f440ba72a3-init/dev/console: operation not supported.
```

```console
$ docker run -it --rm busybox
docker: Error response from daemon: mkdir /var/lib/docker/aufs/mnt/49fabf14d6e814e58f304f6f3fdacb49ae76e8524944aa131ab28f7c31206c8f-init/dev/shm: operation not supported.
```