### PR TITLE
Less permissive file modes for /Users mount

### DIFF
--- a/rootfs/rootfs/etc/rc.d/vbox
+++ b/rootfs/rootfs/etc/rc.d/vbox
@@ -10,7 +10,7 @@ if modprobe vboxguest &> /dev/null && modprobe vboxsf &> /dev/null; then
 	
 	mountOptions='defaults,iocharset=utf8'
 	if grep -q '^docker:' /etc/passwd; then
-		mountOptions="${mountOptions},uid=$(id -u docker),gid=$(id -g docker)"
+		mountOptions="${mountOptions},uid=$(id -u docker),gid=$(id -g docker),fmode=600,dmode=700"
 	fi
 	
 	# try mounting "$name" (which defaults to "$dir") at "$dir",


### PR DESCRIPTION
When mounting C:\Users and the like, at least on Windows (I'm not sure if this is the same if the host OS is OSX in which case this might need adjusting) all files are given mode `777`.  This is a problem for a few reasons that I listed in sagemath/docker-images#19

Setting `600` for files seems to make sense, since for directories under `/Users`/`C:\Users` most files should be private anyways.  I'm split on whether files should be executable or not, but ultimately going with not to be on the safe side.