### PR TITLE
Add support for Docker 1.11.0-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,11 +242,12 @@ RUN depmod -a -b $ROOTFS $KERNEL_VERSION-boot2docker
 COPY VERSION $ROOTFS/etc/version
 RUN cp -v $ROOTFS/etc/version /tmp/iso/version
 
-# Get the Docker version that matches our boot2docker version
-# Note: `docker version` returns non-true when there is no server to ask
-RUN curl -fL -o $ROOTFS/usr/local/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-$(cat $ROOTFS/etc/version) && \
-    chmod +x $ROOTFS/usr/local/bin/docker && \
-    $ROOTFS/usr/local/bin/docker -v
+# Get the Docker binaries with version that matches our boot2docker version.
+# TODO: Verify that binaries execute correctly? Old version ran '$ROOTFS/usr/local/bin/docker -v' to check.
+# TODO(nathanleclaire): 'test' should be 'get' in the next line for the actual releases.
+RUN curl -fSL -o /tmp/dockerbin.tgz https://test.docker.com/builds/Linux/x86_64/docker-$(cat $ROOTFS/etc/version).tgz && \
+    tar zxvf /tmp/dockerbin.tgz -C $ROOTFS/ && \
+    rm /tmp/dockerbin.tgz
 
 # Install Tiny Core Linux rootfs
 RUN cd $ROOTFS && zcat /tcl_rootfs.gz | cpio -f -i -H newc -d --no-absolute-filenames

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -109,7 +109,11 @@ start() {
 }
 
 stop() {
-    kill $(cat /var/run/docker.pid)
+    PID=$(cat /var/run/docker.pid)
+    kill $PID
+    while kill -0 $PID &>/dev/null; do
+        sleep 0.1
+    done
 }
 
 restart() {


### PR DESCRIPTION
This includes a modification to the `Dockerfile` to get the new `docker-*` binaries, and a patch to the `/etc/init.d/docker` script which fixes a newly unearthed race condition in `docker-machine` / `/etc/init.docker/stop`.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>