### PR TITLE
Allow spaces in certificate file names

### DIFF
--- a/rootfs/rootfs/etc/rc.d/install-ca-certs
+++ b/rootfs/rootfs/etc/rc.d/install-ca-certs
@@ -6,7 +6,7 @@ CERTS_DIR=/etc/ssl/certs
 CAFILE=${CERTS_DIR}/ca-certificates.crt
 
 for cert_file in "${BOOT2DOCKER_CERTS_DIR}"/*.pem; do
-	cert=`basename $cert_file`
+	cert=`basename "$cert_file"`
 	echo "installing $cert"
 
 	SRC_CERT_FILE=${BOOT2DOCKER_CERTS_DIR}/${cert}


### PR DESCRIPTION
Although it's conventional for cert file names to use underscores and not spaces, this fix allows `/etc/rc.d/install-ca-certs` to work if `/var/lib/boot2docker/certs` names do contain spaces.