### PR TITLE
Also process certificates with the .crt extension.

### DIFF
--- a/rootfs/rootfs/etc/rc.d/install-ca-certs
+++ b/rootfs/rootfs/etc/rc.d/install-ca-certs
@@ -5,7 +5,7 @@ BOOT2DOCKER_CERTS_DIR=/var/lib/boot2docker/certs
 CERTS_DIR=/etc/ssl/certs
 CAFILE=${CERTS_DIR}/ca-certificates.crt
 
-for cert_file in "${BOOT2DOCKER_CERTS_DIR}"/*.pem; do
+for cert_file in "${BOOT2DOCKER_CERTS_DIR}"/*.pem "${BOOT2DOCKER_CERTS_DIR}"/*.crt; do
 	cert=`basename "$cert_file"`
 	echo "installing $cert"
 


### PR DESCRIPTION
The [official Docker docs on creating a self-signed certificate](https://docs.docker.com/registry/insecure/#using-self-signed-certificates) use a `.crt` extension for the public PEM certificate. To help users that are following those documents, it would help to also accept that extension in this script, as well.