### PR TITLE
document better way to add registry certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,20 @@ more suitable/scalable solution is found and implemented.
 
 #### Installing secure Registry certificates
 
-You can add your Registry server's public certificate (in `.pem` format) into
+As discussed in the [Docker Engine documentation](https://docs.docker.com/engine/security/certificates/#/understanding-the-configuration)
+certificates should be placed at `/etc/docker/certs.d/hostname/ca.crt` 
+where `hostname` is your Registry server's hostname.
+
+```console
+docker-machine scp certfile default:ca.crt
+docker-machine ssh default
+sudo mv ~/ca.crt /etc/docker/certs.d/hostname/ca.crt
+exit
+docker-machine restart
+```
+
+Alternatively the older Boot2Docker method can be used and you can add your 
+Registry server's public certificate (in `.pem` format) into
 the `/var/lib/boot2docker/certs/` directory, and Boot2Docker will automatically
 load it from the persistence partition at boot.
 


### PR DESCRIPTION
Document method more inline with Docker Engine to add registry certs as suggested at https://github.com/boot2docker/boot2docker/pull/1167#issuecomment-226218581.

Fix #347

Related to https://github.com/docker/machine/issues/2247, https://github.com/docker/machine/issues/1799, https://github.com/docker/machine/issues/1963, https://github.com/docker/machine/issues/1872, https://github.com/docker/machine/pull/3690, https://github.com/docker/toolbox/pull/558