### PR TITLE
workaround instead of adding files to /

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -360,8 +360,8 @@ RUN cd /git && \
 # Copy boot params
 COPY rootfs/isolinux /tmp/iso/boot/isolinux
 
-COPY rootfs/make_iso.sh /
+COPY rootfs/make_iso.sh /tmp/make_iso.sh
 
-RUN /make_iso.sh
+RUN /tmp/make_iso.sh
 
 CMD ["sh", "-c", "[ -t 1 ] && exec bash || exec cat boot2docker.iso"]

--- a/Dockerfile.experimental
+++ b/Dockerfile.experimental
@@ -9,4 +9,4 @@ RUN curl -fSL -o /tmp/dockerbin.tgz https://experimental.docker.com/builds/Linux
 
 RUN { echo; echo "  WARNING: this is a build from experimental.docker.com, not a stable release."; echo; } >> "$ROOTFS/etc/motd"
 
-RUN /make_iso.sh
+RUN /tmp/make_iso.sh


### PR DESCRIPTION
- addresses issues where build on the hub fails, such as #1209
- uses workaround based on docker/hub-feedback#811
