### PR TITLE
Upgrade Parallels Tools to v12.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -246,12 +246,11 @@ RUN LD_LIBRARY_PATH=/lib:/usr/local/lib \
         chroot "$ROOTFS" vmhgfs-fuse --version
 
 # Download and build Parallels Tools
-ENV PRL_MAJOR 11
-ENV PRL_VERSION 11.1.0
-ENV PRL_BUILD 32202
+ENV PRL_MAJOR 12
+ENV PRL_VERSION 12.1.0-41489
 
 RUN mkdir -p /prl_tools && \
-    curl -fL http://download.parallels.com/desktop/v${PRL_MAJOR}/${PRL_VERSION}/ParallelsTools-${PRL_VERSION}-${PRL_BUILD}-boot2docker.tar.gz \
+    curl -fL http://download.parallels.com/desktop/v${PRL_MAJOR}/${PRL_VERSION}/ParallelsTools-${PRL_VERSION}-boot2docker.tar.gz \
         | tar -xzC /prl_tools --strip-components 1 && \
     cd /prl_tools && \
     cp -Rv tools/* $ROOTFS && \


### PR DESCRIPTION
Parallels Desktop 12 has been released in August 2016. This PR upgrades Parallels Tools for Boot2Docker up to the latest version (v12.1.0)

Issue #1164 should be fixed there. 

I have verified the build from this branch - everything works fine.