### PR TITLE
Correct the path to make_iso.sh

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -39,7 +39,7 @@ $ sudo docker pull boot2docker/boot2docker
 $ echo "FROM boot2docker/boot2docker" > Dockerfile
 $ echo "ADD . $ROOTFS/data/" >> Dockerfile
 $ echo "RUN somescript.sh" >> Dockerfile
-$ echo "RUN /make_iso.sh" >> Dockerfile
+$ echo "RUN /tmp/make_iso.sh" >> Dockerfile
 $ echo 'CMD ["cat", "boot2docker.iso"]' >> Dockerfile
 
 $ sudo docker build -t my-boot2docker-img .


### PR DESCRIPTION
`make_iso.sh` lives in `/tmp` now, not `/`.

See https://github.com/boot2docker/boot2docker/blob/master/Dockerfile#L369