### PR TITLE
Add new "forgiving-getty" wrapper which verifies that a given TTY is actually a TTY before spawning getty on it (repeatedly)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -325,11 +325,11 @@ RUN find "$ROOTFS/etc/rc.d/" "$ROOTFS/usr/local/etc/init.d/" -type f -exec chmod
 RUN mv -v "$ROOTFS/etc/init.d/dhcp.sh" "$ROOTFS/etc/rc.d/"
 
 # Add serial console
-RUN echo "#!/bin/sh" > $ROOTFS/usr/local/bin/autologin && \
-	echo "/bin/login -f docker" >> $ROOTFS/usr/local/bin/autologin && \
-	chmod 755 $ROOTFS/usr/local/bin/autologin && \
-	echo 'ttyS0:2345:respawn:/sbin/getty -l /usr/local/bin/autologin 9600 ttyS0 vt100' >> $ROOTFS/etc/inittab && \
-	echo 'ttyS1:2345:respawn:/sbin/getty -l /usr/local/bin/autologin 9600 ttyS1 vt100' >> $ROOTFS/etc/inittab
+RUN set -ex; \
+	for s in 0 1 2 3; do \
+		echo "ttyS${s}:2345:respawn:/usr/local/bin/forgiving-getty ttyS${s}" >> "$ROOTFS/etc/inittab"; \
+	done; \
+	cat "$ROOTFS/etc/inittab"
 
 # fix "su -"
 RUN echo root > "$ROOTFS/etc/sysconfig/superuser"

--- a/rootfs/rootfs/usr/local/bin/autologin
+++ b/rootfs/rootfs/usr/local/bin/autologin
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+exec /bin/login -f docker

--- a/rootfs/rootfs/usr/local/bin/forgiving-getty
+++ b/rootfs/rootfs/usr/local/bin/forgiving-getty
@@ -19,12 +19,18 @@ fi
 # https://github.com/systemd/systemd/blob/6a47fd894d601f7e8e88dec4cb35dfb7d7c15eff/src/getty-generator/getty-generator.c#L94-L116
 verify_tty() {
 	local dev="/dev/$1"
+	# can we read the given TTY file at all?
 	test -r "$dev" || return 1
+	# we can! let's open it to file descriptor 42
+	# (random file descriptor not likely to be in use already)
 	exec 42<"$dev" || return 1
 	local ret=1
+	# now that we've got it open, let's use "test" to check whether it's a TTY
+	# (we can't test a file directly, which is why we opened it first)
 	if test -t 42; then
 		ret=0
 	fi
+	# finally, close our file descriptor (no longer necessary to keep open)
 	exec 42<&- || return 1
 	return "$ret"
 }

--- a/rootfs/rootfs/usr/local/bin/forgiving-getty
+++ b/rootfs/rootfs/usr/local/bin/forgiving-getty
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+usage() {
+	self="$(basename "$0")"
+	cat <<-EOUSAGE
+		usage: $self <tty>
+		   ie: $self ttyS0
+		       $self ttyS1
+	EOUSAGE
+}
+
+tty="$1"
+if ! shift || [ -z "$tty" ]; then
+	usage >&2
+	exit 1
+fi
+
+# https://github.com/systemd/systemd/blob/6a47fd894d601f7e8e88dec4cb35dfb7d7c15eff/src/getty-generator/getty-generator.c#L94-L116
+verify_tty() {
+	local dev="/dev/$1"
+	test -r "$dev" || return 1
+	exec 42<"$dev" || return 1
+	local ret=1
+	if test -t 42; then
+		ret=0
+	fi
+	exec 42<&- || return 1
+	return "$ret"
+}
+
+while true; do
+	if verify_tty "$tty"; then
+		/sbin/getty -l /usr/local/bin/autologin 9600 "$tty" vt100
+	else
+		sleep 10
+	fi
+done


### PR DESCRIPTION
Closes #1221
Closes: docker/machine#3711

cc @nathanleclaire @jonathanperret @simonvanderveldt