### PR TITLE
Only attempt to install cert files if they exist

### DIFF
--- a/rootfs/rootfs/etc/rc.d/install-ca-certs
+++ b/rootfs/rootfs/etc/rc.d/install-ca-certs
@@ -6,6 +6,8 @@ CERTS_DIR=/etc/ssl/certs
 CAFILE=${CERTS_DIR}/ca-certificates.crt
 
 for cert_file in "${BOOT2DOCKER_CERTS_DIR}"/*.pem "${BOOT2DOCKER_CERTS_DIR}"/*.crt; do
+	[ -e "$cert_file" ] || continue
+	
 	cert=`basename "$cert_file"`
 	echo "installing $cert"
 


### PR DESCRIPTION
While `install-ca-certs` allows for either `pem` or `crt` files, if no `pem` file is found it will attempt to install `*.pem` which more than likely doesn't exist. This causes a failure when installing a new `crt` file (i.,e., `corporate.crt`) when there are no `pem` files found.

This change simply checks whether `$cert_file` exists and if not, it continues to the next loop iteration.