### PR TITLE
Enable ntpd daemon

### DIFF
--- a/rootfs/rootfs/etc/rc.d/ntpd
+++ b/rootfs/rootfs/etc/rc.d/ntpd
@@ -25,4 +25,4 @@ while ! ping -c 1 $first > /dev/null 2>&1; do
 	fi
 done
 
-ntpd -d -n $args >> /var/lib/boot2docker/log/ntpd.log 2>&1 &
+ntpd -d $args >> /var/lib/boot2docker/log/ntpd.log 2>&1 &


### PR DESCRIPTION
I am using docker-machines as nodes in our Jenkins CI, I noticed that the machines time keeps drifting, After digging into your code, I noticed that the `rc.d/ntpd` sets the Do Not Demonize flag `-n`. After a week or so of monitoring, the time sync seems to be working.
Was there a reason for this flag? If not, is this a possible fix?