### PR TITLE
Fix fsync on dirs in Parallels Shared Folders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -281,6 +281,11 @@ RUN set -ex \
 	&& cd /prl_tools \
 	&& cp -Rv tools/* $ROOTFS \
 	\
+	# Kludge to fix fsync on directory in prl_fs:
+	#   https://github.com/Parallels/docker-machine-parallels/issues/71
+	# Should be removed when fixed in official Parallels Tools.
+	&& sed -E -i 's/(^\t.llseek\t\t= generic_file_llseek,$)/\1\n\t.fsync = noop_fsync,/' \
+		kmods/prl_fs/SharedFolders/Guest/Linux/prl_fs/file.c \
 	&& KERNEL_DIR=/linux-kernel/ KVER="$KERNEL_VERSION" SRC=/linux-kernel/ PRL_FREEZE_SKIP=1 \
 		make -C kmods/ -f Makefile.kmods installme \
 	\


### PR DESCRIPTION
Previously prl_fs didn't provide fsync handler for directory operations
(but for files did). As a result respective syscalls failed. That
caused, for example, problems with running PostgreSQL in containers over
database on a shared volume.

This patch is really a kludge to workaround the issue. And should be
removed when Parallels Tools with fixed prl_fs is incorporated.

Parallels/docker-machine-parallels#71