### PR TITLE
Upgrade Parallels Tools to 13.3.0-43321

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -281,11 +281,6 @@ RUN set -ex \
 	&& cd /prl_tools \
 	&& cp -Rv tools/* $ROOTFS \
 	\
-	# Kludge to fix fsync on directory in prl_fs:
-	#   https://github.com/Parallels/docker-machine-parallels/issues/71
-	# Should be removed when fixed in official Parallels Tools.
-	&& sed -E -i 's/(^\t.llseek\t\t= generic_file_llseek,$)/\1\n\t.fsync = noop_fsync,/' \
-		kmods/prl_fs/SharedFolders/Guest/Linux/prl_fs/file.c \
 	&& KERNEL_DIR=/linux-kernel/ KVER="$KERNEL_VERSION" SRC=/linux-kernel/ PRL_FREEZE_SKIP=1 \
 		make -C kmods/ -f Makefile.kmods installme \
 	\

--- a/Dockerfile
+++ b/Dockerfile
@@ -271,8 +271,8 @@ RUN LD_LIBRARY_PATH='/lib:/usr/local/lib' \
 		chroot "$ROOTFS" vmhgfs-fuse --version
 
 # Download and build Parallels Tools
-ENV PRL_MAJOR 12
-ENV PRL_VERSION 12.1.3-41532
+ENV PRL_MAJOR 13
+ENV PRL_VERSION 13.3.0-43321
 
 RUN set -ex \
 	&& mkdir -p /prl_tools \


### PR DESCRIPTION
Parallels Desktop v13.3.0 has been recently released. Guest tools for boot2docker were published too.

@romankulikov Can the fix from https://github.com/boot2docker/boot2docker/pull/1294 be reverted, after merging this Pull-Request?