### PR TITLE
Add Transparent Proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN set -eux; \
 		golang \
 		isolinux \
 		kmod \
+		libssl1.0-dev libevent-dev=2.0.21-stable-3 \
 		p7zip-full \
 		pkg-config \
 		squashfs-tools \
@@ -100,6 +101,34 @@ RUN curl -fL http://http.debian.net/debian/pool/main/libc/libcap2/libcap2_2.22.o
     make prefix=`pwd`/output install && \
     mkdir -p $ROOTFS/usr/local/lib && \
     cp -av `pwd`/output/lib64/* $ROOTFS/usr/local/lib
+
+# Install cntlm
+RUN curl -fL http://http.debian.net/debian/pool/main/c/cntlm/cntlm_0.92.3.orig.tar.gz | tar -C / -xz && \
+    cd /cntlm-0.92.3 && \
+    mkdir -p output && \
+    sed -i 's/DESTDIR=/DESTDIR=`pwd`\/output/' Makefile && \
+    ./configure --prefix=`pwd`/output && \
+    make && \
+    make install && \
+    mkdir -p $ROOTFS/usr/local/sbin && \
+    cp -av `pwd`/output/usr/sbin/cntlm $ROOTFS/usr/local/sbin/cntlm
+
+# Install libevent
+RUN curl -fL http://http.debian.net/debian/pool/main/libe/libevent/libevent_2.0.21-stable.orig.tar.gz | tar -C / -xz && \
+    cd /libevent-2.0.21-stable && \
+    mkdir -p output && \
+    ./configure --prefix=`pwd`/output && \
+    make && \
+    make install && \
+    mkdir -p $ROOTFS/lib && \
+    cp -av `pwd`/output/lib/*.so* $ROOTFS/lib
+
+# Install redsocks
+RUN curl -fL http://http.debian.net/debian/pool/main/r/redsocks/redsocks_0.5.orig.tar.gz | tar -C / -xz && \
+    cd /redsocks-release-0.5 && \
+    make && \
+    mkdir -p $ROOTFS/usr/local/sbin && \
+    cp -av `pwd`/redsocks $ROOTFS/usr/local/sbin/redsocks
 
 # Make sure the kernel headers are installed for aufs-util, and then build it
 ENV AUFS_UTIL_REPO    https://git.code.sf.net/p/aufs/aufs-util

--- a/rootfs/rootfs/etc/rc.d/transparent_proxy
+++ b/rootfs/rootfs/etc/rc.d/transparent_proxy
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/etc/init.d/transparent_proxy start

--- a/rootfs/rootfs/opt/bootscript.sh
+++ b/rootfs/rootfs/opt/bootscript.sh
@@ -65,6 +65,9 @@ date
 ip a
 echo "-------------------"
 
+# Launch transparent proxy
+/etc/rc.d/transparent_proxy
+
 # Allow local bootsync.sh customisation
 if [ -e /var/lib/boot2docker/bootsync.sh ]; then
     /bin/sh /var/lib/boot2docker/bootsync.sh

--- a/rootfs/rootfs/usr/local/etc/init.d/docker
+++ b/rootfs/rootfs/usr/local/etc/init.d/docker
@@ -103,6 +103,10 @@ start() {
     ulimit -n $DOCKER_ULIMITS
     ulimit -p $DOCKER_ULIMITS
 
+    # docker-machine provision executes start only on docker service.
+    # We need to trigger reconfiguration on transparent proxy.
+    /usr/local/etc/init.d/transparent_proxy restart
+
     echo "------------------------" >> "$DOCKER_LOGFILE"
     echo "/usr/local/bin/dockerd -g \"$DOCKER_DIR\" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> \"$DOCKER_LOGFILE\"" >> "$DOCKER_LOGFILE"
     /usr/local/bin/dockerd -g "$DOCKER_DIR" -H unix:// $DOCKER_HOST $EXTRA_ARGS >> "$DOCKER_LOGFILE" 2>&1 &

--- a/rootfs/rootfs/usr/local/etc/init.d/transparent_proxy
+++ b/rootfs/rootfs/usr/local/etc/init.d/transparent_proxy
@@ -1,0 +1,173 @@
+#!/bin/sh
+# transparent proxy start script
+
+[ $(id -u) = 0 ] || { echo 'must be root' ; exit 1; }
+
+# import settings from profile
+test -f '/var/lib/boot2docker/profile' && . '/var/lib/boot2docker/profile'
+
+start() {
+  [ -z "${TRANSPARENT_HTTP_PROXY}" ] && exit 1
+  check && echo "Transparent proxy is already running" && exit 1
+  stop > /dev/null 2>&1
+
+  echo "Starting transparent proxy"
+
+  configure_and_start_cntlm
+  configure_and_start_redsocks
+  configure_ip_tables
+}
+
+stop() {
+  echo "Stopping transparent proxy"
+  clear_ip_tables
+  
+  PID=$(cat /var/run/redsocks.pid)
+  if [ -n "${PID}" ]; then
+    kill $PID
+    while kill -0 $PID &>/dev/null; do
+      sleep 0.1
+    done
+  fi
+
+  PID=$(cat /var/run/cntlm.pid)
+  if [ -n "${PID}" ]; then
+    kill $PID
+    while kill -0 $PID &>/dev/null; do
+      sleep 0.1
+    done
+  fi
+}
+
+restart() {
+  if check; then
+    stop
+    i=30
+    while check ; do
+      sleep 1
+      i=$(expr $i - 1)
+      [ "$i" -gt 0 ] || { echo "Failed to stop transparent proxy" ; exit 1 ; }
+    done
+  fi
+  start
+}
+
+status() {
+  if check; then
+    echo 'Transparent proxy is running'
+    exit 0
+  else
+    echo 'Transparent proxy is not running'
+    exit 1
+  fi
+}
+
+check() {
+  [ -f /var/run/redsocks.pid ] && ps -A -o pid | grep "^\s*$(cat /var/run/redsocks.pid)$" > /dev/null 2>&1 && \
+  [ -f /var/run/cntlm.pid ] && ps -A -o pid | grep "^\s*$(cat /var/run/cntlm.pid)$" > /dev/null 2>&1
+}
+
+configure_and_start_cntlm() {
+  SCHEMELESS_HTTP_PROXY_URL=$(echo "${TRANSPARENT_HTTP_PROXY}" | awk '{ IGNORECASE = 1; sub(/^http[s]?:\/\//, "", $0); print $0 }')
+  case "${SCHEMELESS_HTTP_PROXY_URL}" in
+  *@*) # proxy with credentials
+    PROXY_URL=$(echo "${SCHEMELESS_HTTP_PROXY_URL}" | cut -d '@' -f2)
+    PROXY_CREDENTIALS=$(echo "${SCHEMELESS_HTTP_PROXY_URL}" | cut -d '@' -f1)
+    PROXY_USER=$(echo "${PROXY_CREDENTIALS}" | cut -d ':' -f1)
+    PROXY_PASSWORD=$(echo "${PROXY_CREDENTIALS}" | cut -d ':' -f2)
+    CNTLM_PASS=$(url_decode "${PROXY_PASSWORD}" | cntlm -u "${PROXY_USER}" -d "${TRANSPARENT_HTTP_PROXY_DOMAIN}" -H | grep -v Password:)
+    cat << EOF > /etc/cntlm.conf
+Username        ${PROXY_USER}
+Domain          ${TRANSPARENT_HTTP_PROXY_DOMAIN}
+
+${CNTLM_PASS}
+
+Proxy ${PROXY_URL}
+NoProxy	${TRANSPARENT_NO_PROXY}
+Listen	3128
+Gateway	yes
+Auth    NTLM
+EOF
+  ;;
+  *) # proxy without credentials
+    cat << EOF > /etc/cntlm.conf
+Proxy ${SCHEMELESS_HTTP_PROXY_URL}
+NoProxy	${TRANSPARENT_NO_PROXY}
+Listen	3128
+Gateway	yes
+EOF
+  ;;
+  esac
+
+  cntlm -c /etc/cntlm.conf -P /var/run/cntlm.pid > /var/lib/boot2docker/log/cntlm.log 2>&1
+}
+
+url_decode() {
+    URL_ENCODED="${1//+/ }"
+    printf '%b' "${URL_ENCODED//%/\\x}"
+}
+
+configure_and_start_redsocks() {
+  cat << EOF > /etc/redsocks.conf
+base {
+  log_debug = off;
+  log_info = off;
+  log = "file:/var/lib/boot2docker/log/redsocks.log";
+  daemon = on;
+  user = root;
+  group = root;
+  redirector = iptables;
+}
+
+redsocks {
+  local_ip = 0.0.0.0;
+  local_port = 3129;
+  ip = 127.0.0.1;
+  port = 3128;
+  type = "http-connect";
+}
+EOF
+
+  redsocks -c /etc/redsocks.conf -p /var/run/redsocks.pid
+}
+
+configure_ip_tables() {
+  PROXY_HOST=$(echo "${TRANSPARENT_HTTP_PROXY}" | sed -e "s/\([^/]*\/\/\)\?\([^@]*@\)\?\([^:/]*\).*/\3/")
+  iptables -w -t nat -N PROXY
+  iptables -w -t nat -A PROXY -d 0.0.0.0/8 -j RETURN
+  iptables -w -t nat -A PROXY -d 10.0.0.0/8 -j RETURN
+  iptables -w -t nat -A PROXY -d 127.0.0.0/8 -j RETURN
+  iptables -w -t nat -A PROXY -d 172.16.0.0/12 -j RETURN
+  iptables -w -t nat -A PROXY -d 192.168.0.0/16 -j RETURN
+
+  for ip in $(nslookup $PROXY_HOST 2>/dev/null | awk '/Name:/,EOF' | awk '/^Address [0-9]+: / { print $3 }')
+  do
+    iptables -w -t nat -A PROXY -d $ip -j RETURN
+  done
+
+  : ${TRANSPARENT_HTTP_PROXY_PORTS:='80,443'}
+  OLD_IFS=${IFS}
+  export IFS=","
+  for p in ${TRANSPARENT_HTTP_PROXY_PORTS}; do
+    iptables -w -t nat -A PROXY -p tcp --dport "${p}" -j REDIRECT --to-ports 3129
+  done
+  export IFS=${OLD_IFS}
+
+  iptables -w -t nat -A PROXY -j RETURN
+
+  iptables -w -t nat -A OUTPUT -p tcp -j PROXY
+}
+
+clear_ip_tables() {
+  iptables -w -t nat -D OUTPUT -p tcp -j PROXY
+  iptables -w -t nat -F PROXY
+  iptables -w -t nat -X PROXY
+}
+
+case $1 in
+  start) start;;
+  stop) stop;;
+  restart) restart;;
+  status) status;;
+  *) echo "Usage $0 {start|stop|restart|status}"; exit 1
+esac


### PR DESCRIPTION
Running Docker in the environment with HTTP(S) proxy, which is still common in the corporate networks,
is hard because you have to provide the proxy address and authentication in multiple places.

Internet access is needed for example for:

* pulling images from Docker Hub
* downloading packages while building Docker images
* containers communication to the Internet

Setting `http_proxy` and `https_proxy` environment variables is usually not sufficient - not all programs support it.
To address this problem Boot2docker is capable of redirecting HTTP and HTTPS traffic to the proxy transparently,
but it requires some additional Docker Machine setup.

In the nutshell, either provide HTTP(S) proxy url via `--engine-env TRANSPARENT_HTTP_PROXY=user:password@proxy-host.com`
when creating a new Docker Machine or in `~/.docker/machine/machines/{machineName}/config.json` for existing machines.

This solution uses `iptables` and [redsocks](https://github.com/darkk/redsocks) to redirect tcp traffic
to [cntlm](http://cntlm.sourceforge.net).