### PR TITLE
Adding QEMU Guest Agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -309,6 +309,20 @@ RUN set -ex \
 	&& cp hv_kvp_daemon $ROOTFS/usr/sbin \
 	&& rm -rf /tmp/kheaders
 
+# Install QEMU Guest Agent
+# (extracting binary only)
+ENV QEMUGA_DEPS qemu
+# changed in TC 9 into qemu-common
+RUN set -ex; \
+	for dep in $QEMUGA_DEPS; do \
+		echo "Download $TCL_REPO_BASE/tcz/$dep.tcz"; \
+		curl -fL -o "/tmp/$dep.tcz" "$TCL_REPO_BASE/tcz/$dep.tcz" \
+			|| curl -fL -o "/tmp/$dep.tcz" "$TCL_REPO_FALLBACK/tcz/$dep.tcz"; \
+		unsquashfs -f -d "$ROOTFS" "/tmp/$dep.tcz" /usr/local/bin/qemu-ga; \
+		rm -f "/tmp/$dep.tcz"; \
+	done
+
+
 # Make sure that all the modules we might have added are recognized (especially VBox guest additions)
 RUN depmod -a -b "$ROOTFS" "$KERNEL_VERSION-boot2docker"
 

--- a/rootfs/rootfs/etc/rc.d/qemu-guest-agent
+++ b/rootfs/rootfs/etc/rc.d/qemu-guest-agent
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+SYSTYPE=$(cat /sys/class/dmi/id/sys_vendor | grep -ic qemu)
+
+if [ "$SYSTYPE" -gt 0 ]; then
+    /usr/local/bin/qemu-ga --daemonize -m virtio-serial -p /dev/virtio-ports/org.qemu.guest_agent.0
+fi

--- a/rootfs/rootfs/opt/bootscript.sh
+++ b/rootfs/rootfs/opt/bootscript.sh
@@ -93,3 +93,6 @@ fi
 
 # Load Parallels Tools daemon
 /etc/rc.d/prltoolsd
+
+# Load QEMU Guest agent
+/etc/rc.d/qemu-guest-agent


### PR DESCRIPTION
For better integration into KVM/QEMU, the guest agent is started
analogously to the VMware, Hyper-V, XEN and Parallels agents.