### PR TITLE
Update open-vm-tools to 10.2.5-8068406

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -233,9 +233,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Build VMware Tools
-ENV OVT_VERSION 10.0.0-3000743
+ENV OVT_VERSION stable-10.2.5
 
-RUN curl --retry 10 -fsSL "https://github.com/vmware/open-vm-tools/archive/open-vm-tools-${OVT_VERSION}.tar.gz" | tar -xz --strip-components=1 -C /
+RUN curl --retry 10 -fsSL "https://github.com/vmware/open-vm-tools/archive/${OVT_VERSION}.tar.gz" | tar -xz --strip-components=1 -C /
 
 # Compile user space components, we're no longer building kernel module as we're
 # now bundling FUSE shared folders support.


### PR DESCRIPTION
The currently bundled version of open-vm-tools has an issue where only 16 IPs are going to be reported to the vmware hypervisor, and the link local IP addresses of veth* NICs are included. The end result is that if you start up a large compose file, the VM's own IP will be pushed out of the reported guest IPs list, and commands such as `docker-machine env` and `docker-machine ip` will hang.

See vmware/open-vm-tools#100