### PR TITLE
Add two separate solutions to the "empty resolv.conf" issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV TCL_VERSION 8.2.1
 # updated via "update.sh"
 ENV TCL_ROOTFS="rootfs64.gz" TCL_ROOTFS_MD5="b4991d3c07b88649b61616f86f2f079f"
 
-COPY files/tce-load.patch /
+COPY files/tce-load.patch files/udhcpc.patch /tcl-patches/
 
 RUN for mirror in $TCL_MIRRORS; do \
 		if \
@@ -62,6 +62,14 @@ RUN for mirror in $TCL_MIRRORS; do \
 	; \
 	rm /rootfs.gz; \
 	\
+	for patch in /tcl-patches/*.patch; do \
+		patch \
+			--input "$patch" \
+			--strip 1 \
+			--verbose \
+		; \
+	done; \
+	\
 	{ \
 		echo '# https://1.1.1.1/'; \
 		echo 'nameserver 1.1.1.1'; \
@@ -71,6 +79,7 @@ RUN for mirror in $TCL_MIRRORS; do \
 		echo 'nameserver 8.8.8.8'; \
 		echo 'nameserver 8.8.4.4'; \
 	} > etc/resolv.conf; \
+	cp etc/resolv.conf etc/resolv.conf.b2d; \
 	{ \
 		echo '#!/usr/bin/env bash'; \
 		echo 'set -Eeuo pipefail'; \
@@ -137,12 +146,6 @@ RUN for package in $TCL_PACKAGES; do \
 		[ -x "$script" ] || continue; \
 		tcl-chroot "$script"; \
 	done; \
-	\
-	patch \
-		--input /tce-load.patch \
-		--strip 1 \
-		--verbose \
-	; \
 	\
 	{ \
 		echo '#!/bin/bash -Eeux'; \

--- a/files/init.d/docker
+++ b/files/init.d/docker
@@ -61,11 +61,21 @@ pid() {
 	return 1
 }
 
+_ensure_resolvconf() {
+	# sometimes (especially on VBox), "/etc/resolv.conf" ends up empty
+	# we detect that here and replace it with our original version since Docker needs it
+	if [ ! -s /etc/resolv.conf ]; then
+		cp -fT /etc/resolv.conf.b2d /etc/resolv.conf
+	fi
+}
+
 start() {
 	if pid="$(pid)"; then
 		echo >&2 "error: Docker daemon is already running ($pid)"
 		exit 1
 	fi
+
+	_ensure_resolvconf
 
 	if [ ! -e /etc/docker ]; then
 		echo 'Linking /etc/docker to /var/lib/boot2docker for persistence'

--- a/files/udhcpc.patch
+++ b/files/udhcpc.patch
@@ -1,0 +1,17 @@
+Description: only empty "resolv.conf" when we get DNS from DHCP
+Author: "aheissenberger", Tianon Gravi
+Origin: http://forum.tinycorelinux.net/index.php/topic,16482.msg98078.html#msg98078
+
+diff --git a/usr/share/udhcpc/default.script b/usr/share/udhcpc/default.script
+index 98ebc15..abe4178 100755
+--- a/usr/share/udhcpc/default.script
++++ b/usr/share/udhcpc/default.script
+@@ -28,7 +28,7 @@ case "$1" in
+ 			done
+ 		fi
+ 
+-		echo -n > $RESOLV_CONF
++		[ -n "$dns" ] && echo -n > $RESOLV_CONF
+ 		[ -n "$domain" ] && echo search $domain >> $RESOLV_CONF
+ 		for i in $dns ; do
+ 			echo adding dns $i


### PR DESCRIPTION
This primarily appears to happen because we have two networks and run DHCP on both, resulting in a cleared out `/etc/resolv.conf` _sometimes_ (depending on which DHCP response our VM processed last).

This is as noted in https://github.com/boot2docker/boot2docker/pull/1343#issuecomment-436451793.