### PR TITLE
Add tun/tap support which is removed now

### DIFF
--- a/files/kernel-config.d/tun
+++ b/files/kernel-config.d/tun
@@ -1,0 +1,1 @@
+CONFIG_TUN=y


### PR DESCRIPTION
Readd tun/tap support to kernel which was removed in c2b60ab21080d15148948fc6536078251dcfa842

With you latest update in c2b60ab21080d15148948fc6536078251dcfa842 you've removed the tun/tap support entirely - which is very bad if someone use the docker container with openvpn.