### PR TITLE
Fix volume ID for docker-machine

### DIFF
--- a/files/make-b2d-iso.sh
+++ b/files/make-b2d-iso.sh
@@ -6,9 +6,12 @@ find -not -name '*.tcz' \
 	| xz -9 --format=lzma --verbose --verbose --threads=0 --extreme \
 	> /tmp/iso/boot/initrd.img
 
+# volume label (https://github.com/boot2docker/boot2docker/issues/1347)
+volumeLabel="b2d-v$DOCKER_VERSION"
+
 xorriso \
 	-as mkisofs -o /tmp/boot2docker.iso \
-	-A 'Boot2Docker' -V 'Boot2Docker' \
+	-A 'Boot2Docker' -V "$volumeLabel" \
 	-isohybrid-mbr /tmp/isohdpfx.bin \
 	-partition_offset 16 \
 	-b isolinux/isolinux.bin \


### PR DESCRIPTION
Fixes #1347

```console
$ isoinfo -d -i boot2docker.iso
CD-ROM is in ISO 9660 format
System id: 
Volume id: b2d-v18.09.0
Volume set id: 
Publisher id: 
Data preparer id: XORRISO-1.4.6 2016.09.16.133001, LIBISOBURN-1.4.6, LIBISOFS-1.4.6, LIBBURN-1.4.6
Application id: BOOT2DOCKER
Copyright File id: 
Abstract File id: 
Bibliographic File id: 
Volume set size is: 1
Volume set sequence number is: 1
Logical block size is: 2048
Volume size is: 23040
El Torito VD version 1 found, boot catalog is in sector 49
NO Joliet present
Rock Ridge signatures version 1 found
Eltorito validation header:
    Hid 1
    Arch 0 (x86)
    ID ''
    Key 55 AA
    Eltorito defaultboot header:
        Bootid 88 (bootable)
        Boot media 0 (No Emulation Boot)
        Load segment 0
        Sys type 0
        Nsect 4
        Bootoff 32 50
```