### PR TITLE
Drop "-partition_offset" from "xorriso" invocation to fix xhyve / Mac OS mounting the ISO

### DIFF
--- a/files/make-b2d-iso.sh
+++ b/files/make-b2d-iso.sh
@@ -11,9 +11,9 @@ volumeLabel="b2d-v$DOCKER_VERSION"
 
 xorriso \
 	-as mkisofs -o /tmp/boot2docker.iso \
-	-A 'Boot2Docker' -V "$volumeLabel" \
+	-A 'Boot2Docker' \
+	-V "$volumeLabel" \
 	-isohybrid-mbr /tmp/isohdpfx.bin \
-	-partition_offset 16 \
 	-b isolinux/isolinux.bin \
 	-c isolinux/boot.cat \
 	-no-emul-boot \


### PR DESCRIPTION
I've personally tested this successfully with https://github.com/machine-drivers/docker-machine-driver-xhyve/releases/tag/v0.3.3. :+1:

Fixes #1355
Refs https://github.com/machine-drivers/docker-machine-driver-xhyve/issues/211