### PR TITLE
added missing mkdir for /var/lib/boot2docker/etc causing following er…

### DIFF
--- a/files/bootsync.sh
+++ b/files/bootsync.sh
@@ -15,6 +15,9 @@ cgroupfs-mount
 mkdir -p /var/lib/boot2docker/log
 chown docker /var/lib/boot2docker/log
 
+mkdir -p /var/lib/boot2docker/etc
+chown docker /var/lib/boot2docker/etc
+
 # wouldn't it be great if ntpd had a "log to XYZ file" option? (like crond does!)
 ntpd -d -n -q >> /var/lib/boot2docker/log/ntp.log 2>&1
 ntpd -d -n >> /var/lib/boot2docker/log/ntp.log 2>&1 &

--- a/files/bootsync.sh
+++ b/files/bootsync.sh
@@ -4,6 +4,10 @@
 mkdir -p /var/lib/boot2docker
 chown docker:docker /var/lib/boot2docker
 
+# make sure "/var/lib/boot2docker/etc" exists for docker-machine to write into and read "hostname" from it if it exists from a previous boot
+# https://github.com/docker/machine/blob/7a9ce457496353549916e840874012a97e3d2782/libmachine/provision/boot2docker.go#L113
+mkdir -p /var/lib/boot2docker/etc
+
 if [ -s /var/lib/boot2docker/etc/hostname ]; then
 	# https://github.com/docker/machine/blob/97c1136d1ec9ae4c3ab69fda615e3dd577809e5c/libmachine/provision/boot2docker.go#L113
 	hostname="$(cat /var/lib/boot2docker/etc/hostname)"
@@ -14,9 +18,6 @@ cgroupfs-mount
 
 mkdir -p /var/lib/boot2docker/log
 chown docker /var/lib/boot2docker/log
-
-mkdir -p /var/lib/boot2docker/etc
-chown docker /var/lib/boot2docker/etc
 
 # wouldn't it be great if ntpd had a "log to XYZ file" option? (like crond does!)
 ntpd -d -n -q >> /var/lib/boot2docker/log/ntp.log 2>&1


### PR DESCRIPTION
…ror:

Error creating machine: Error running provisioning: ssh command error:
command : sudo /usr/bin/sethostname test && echo "test" | sudo tee /var/lib/boot2docker/etc/hostname