### PR TITLE
Add "CONFIG_NET_SCH_NETEM" for network delay/loss emulation

### DIFF
--- a/files/kernel-config.d/networking
+++ b/files/kernel-config.d/networking
@@ -1,0 +1,4 @@
+CONFIG_TUN=y
+
+# https://github.com/boot2docker/boot2docker/issues/1384
+CONFIG_NET_SCH_NETEM=m

--- a/files/kernel-config.d/tun
+++ b/files/kernel-config.d/tun
@@ -1,1 +1,0 @@
-CONFIG_TUN=y


### PR DESCRIPTION
Closes #1384

It was tempting to also combine `ebpf` into this file, but I think the scope of eBPF in general is much larger than networking.