### PR TITLE
Pin VBoxGuestAdditions to 5.x (revert VBoxControl changes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -355,9 +355,9 @@ RUN ( cd /usr/src/haveged && ./configure LDFLAGS='-static --static' ); \
 
 # http://download.virtualbox.org/virtualbox/
 # updated via "update.sh"
-ENV VBOX_VERSION 6.0.10
+ENV VBOX_VERSION 5.2.32
 # https://www.virtualbox.org/download/hashes/$VBOX_VERSION/SHA256SUMS
-ENV VBOX_SHA256 c8a686f8c7ad9ca8375961ab19815cec6b1f0d2496900a356a38ce86fe8a1325
+ENV VBOX_SHA256 4311c7408a3410e6a33264a9062347d9eec04f58339a49f0a60488c0cabc8996
 # (VBoxGuestAdditions_X.Y.Z.iso SHA256, for verification)
 
 RUN wget -O /vbox.iso "https://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso"; \

--- a/files/init.d/vbox
+++ b/files/init.d/vbox
@@ -44,7 +44,7 @@ start() {
 			return 0
 		}
 
-		shares="$(VBoxControl --nologo sharedfolder list --automount | tail -n+3 | cut  -d ' ' -f 3)"
+		shares="$(VBoxControl --nologo sharedfolder list -automount | tail -n+3 | cut  -d ' ' -f 3)"
 		for line in $shares; do
 			try_mount_share "$line"
 		done

--- a/update.sh
+++ b/update.sh
@@ -22,6 +22,9 @@ mirrors=(
 
 # https://www.kernel.org/
 kernelBase='4.14'
+# https://github.com/boot2docker/boot2docker/issues/1398
+# https://download.virtualbox.org/virtualbox/
+vboxBase='5'
 
 # avoid issues with slow Git HTTP interactions (*cough* sourceforge *cough*)
 export GIT_HTTP_LOW_SPEED_LIMIT='100'
@@ -100,7 +103,14 @@ seds+=(
 	-e 's!^(ENV LINUX_VERSION).*!\1 '"$kernelVersion"'!'
 )
 
-vboxVersion="$(wget -qO- 'https://download.virtualbox.org/virtualbox/LATEST-STABLE.TXT')"
+#vboxVersion="$(wget -qO- 'https://download.virtualbox.org/virtualbox/LATEST-STABLE.TXT')"
+vboxVersion="$(
+	wget -qO- 'https://download.virtualbox.org/virtualbox/' \
+		| grep -oE 'href="[0-9.]+/?"' \
+		| cut -d'"' -f2 | cut -d/ -f1 \
+		| grep -E "^$vboxBase[.]" \
+		| tail -1
+)"
 vboxSha256="$(
 	{
 		wget -qO- "https://download.virtualbox.org/virtualbox/$vboxVersion/SHA256SUMS" \


### PR DESCRIPTION
This reverts commit b5def189c5a5b577387090671651f5dee9576fde (#1396).

Fixes https://github.com/boot2docker/boot2docker/issues/1398