### PR TITLE
Swap TCL's squashfs-tools for a static compiled version instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,38 +119,27 @@ RUN mkdir -p proc; \
 	echo -n docker > etc/sysconfig/tcuser; \
 	tcl-chroot sh -c '. /etc/init.d/tc-functions && setupHome'
 
-# packages (and their deps) that we either need for our "tce-load" patches or that dep on "...-KERNEL" which we don't need (since we build our own kernel)
-# http://distro.ibiblio.org/tinycorelinux/8.x/x86_64/tcz/squashfs-tools.tcz.dep
-# http://distro.ibiblio.org/tinycorelinux/8.x/x86_64/tcz/squashfs-tools.tcz.md5.txt
-# updated via "update.sh"
-ENV TCL_PACKAGES="squashfs-tools.tcz liblzma.tcz lzo.tcz libzstd.tcz" TCL_PACKAGE_MD5__squashfs_tools_tcz="a44331fa2117314e62267147b6876a49" TCL_PACKAGE_MD5__liblzma_tcz="846ce1b68690e46f61aff2f952da433f" TCL_PACKAGE_MD5__lzo_tcz="c9a1260675774c50cea1a490978b100d" TCL_PACKAGE_MD5__libzstd_tcz="a7f383473a4ced6c79e8b1a0cc9ad167"
+# as of squashfs-tools 4.4, TCL's unsquashfs is broken... (fails to unsquashfs *many* core tcz files)
+# https://github.com/plougher/squashfs-tools/releases
+ENV SQUASHFS_VERSION 4.4
+RUN wget -O squashfs.tgz "https://github.com/plougher/squashfs-tools/archive/$SQUASHFS_VERSION.tar.gz"; \
+	tar --directory=/usr/src --extract --file=squashfs.tgz; \
+	make -C "/usr/src/squashfs-tools-$SQUASHFS_VERSION/squashfs-tools" \
+		-j "$(nproc)" \
+# https://github.com/plougher/squashfs-tools/blob/4.4/squashfs-tools/Makefile#L1
+		GZIP_SUPPORT=1 \
+#		XZ_SUPPORT=1 \
+#		LZO_SUPPORT=1 \
+#		LZ4_SUPPORT=1 \
+#		ZSTD_SUPPORT=1 \
+		EXTRA_CFLAGS='-static' \
+		EXTRA_LDFLAGS='-static' \
+		INSTALL_DIR="$PWD/usr/local/bin" \
+		install \
+	; \
+	tcl-chroot unsquashfs -v || :
 
-RUN for package in $TCL_PACKAGES; do \
-		eval 'md5="$TCL_PACKAGE_MD5__'"$(echo "$package" | sed -r 's/[^a-zA-Z0-9]+/_/g')"'"'; \
-		echo "$md5 *$package" > "usr/local/tce.installed/optional/$package.md5.txt"; \
-		for mirror in $TCL_MIRRORS; do \
-			if \
-				wget -O "usr/local/tce.installed/optional/$package" "$mirror/$TCL_MAJOR/x86_64/tcz/$package" \
-				&& ( cd usr/local/tce.installed/optional && md5sum -c "$package.md5.txt" ) \
-			; then \
-				break; \
-			fi; \
-		done; \
-		( cd usr/local/tce.installed/optional && md5sum -c "$package.md5.txt" ); \
-		unsquashfs -dest . -force "usr/local/tce.installed/optional/$package"; \
-		touch "usr/local/tce.installed/${package%.tcz}"; \
-# pretend this package has no deps (we already installed them)
-		touch "usr/local/tce.installed/optional/$package.dep"; \
-	done; \
-	\
-	tcl-chroot ldconfig; \
-	for script in usr/local/tce.installed/*; do \
-		[ -f "$script" ] || continue; \
-		[ -x "$script" ] || continue; \
-		tcl-chroot "$script"; \
-	done; \
-	\
-	{ \
+RUN { \
 		echo '#!/bin/bash -Eeux'; \
 		echo 'tcl-chroot su -c "tce-load -wicl \"\$@\"" docker -- - "$@"'; \
 	} > /usr/local/bin/tcl-tce-load; \

--- a/files/tce-load.patch
+++ b/files/tce-load.patch
@@ -1,6 +1,7 @@
 Description: replace "mount" with "unsquashfs" and ignore "-KERNEL" deps
 Author: Tatsushi Demachi, Tianon Gravi
 Partial-Origin: https://github.com/tatsushid/docker-tinycore/blob/017b258a08a41399f65250c9865a163226c8e0bf/8.2/x86_64/src/tce-load.patch
+Unpatched-Source: https://github.com/tinycorelinux/Core-scripts/blob/19fed4fa59585899ef47163424b15f59f15d3e4d/usr/bin/tce-load
 
 diff --git a/usr/bin/tce-load b/usr/bin/tce-load
 index 1378b90..fea2aa8 100755
@@ -11,7 +12,7 @@ index 1378b90..fea2aa8 100755
  copyInstall() {
  	[ -d /mnt/test ] || sudo /bin/mkdir -p /mnt/test
 -	sudo /bin/mount $1 /mnt/test -t squashfs -o loop,ro,bs=4096
-+	sudo /usr/local/bin/unsquashfs -f -d /mnt/test $1
++	sudo /usr/local/bin/unsquashfs -force -dest /mnt/test $1 || exit 1
  	if [ "$?" == 0 ]; then
  		if [ "$(ls -A /mnt/test)" ]; then
  			yes "$FORCE" | sudo /bin/cp -ai /mnt/test/. / 2>/dev/null

--- a/update.sh
+++ b/update.sh
@@ -6,15 +6,6 @@ major='10.x'
 version='10.1' # TODO auto-detect latest
 # 9.x doesn't seem to use ".../archive/X.Y.Z/..." in the same way as 8.x :(
 
-packages=(
-	# needed for "tce-load.patch"
-	squashfs-tools.tcz
-
-	# required for Docker, deps on "xyz-KERNEL.tcz"
-	#iptables.tcz
-	# fixed via tce-load patch instead (more sustainable)
-)
-
 mirrors=(
 	http://distro.ibiblio.org/tinycorelinux
 	http://repo.tinycorelinux.net
@@ -65,34 +56,6 @@ rootfsMd5="$(
 rootfsMd5="${rootfsMd5%% *}"
 seds+=(
 	-e 's/^ENV TCL_ROOTFS.*/ENV TCL_ROOTFS="'"$rootfs"'" TCL_ROOTFS_MD5="'"$rootfsMd5"'"/'
-)
-
-archPackages=()
-archPackagesMd5s=()
-declare -A seen=()
-set -- "${packages[@]}"
-while [ "$#" -gt 0 ]; do
-	package="$1"; shift
-	[ -z "${seen[$package]:-}" ] || continue
-	seen[$package]=1
-
-	packageMd5="$(fetch "$arch/tcz/$package.md5.txt")"
-	packageMd5="${packageMd5%% *}"
-
-	archPackages+=( "$package" )
-	archPackagesMd5s+=(
-		'TCL_PACKAGE_MD5__'"$(echo "$package" | sed -r 's/[^a-zA-Z0-9]+/_/g')"'="'"$packageMd5"'"'
-	)
-
-	if packageDeps="$(
-		fetch "$arch/tcz/$package.dep" \
-			| grep -vE -- '-KERNEL'
-	)"; then
-		set -- $packageDeps "$@"
-	fi
-done
-seds+=(
-	-e 's!^ENV TCL_PACKAGES.*!ENV TCL_PACKAGES="'"${archPackages[*]}"'" '"${archPackagesMd5s[*]}"'!'
 )
 
 kernelVersion="$(


### PR DESCRIPTION
For some reason, the latest 4.4 upload of squashfs-tools in TCL 10.x fails to extract many/most .tcz files from TCL.  On the flip side, it's really easy to compile statically and the `Dockerfile` is much cleaner, so we're going with it.